### PR TITLE
fix(setup): detect Windows tool installs in Git Bash

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,16 +19,59 @@ echo "  ClaudeMaxPower — Setup"
 echo "============================================"
 echo ""
 
+# On Git Bash / MSYS / Cygwin, the bash inherits a limited PATH from cmd.exe
+# that often omits user-level and Program Files tool installs. Augment PATH
+# with the common Windows install locations so command -v can find .exe tools.
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  MINGW*|MSYS*|CYGWIN*)
+    WIN_USER="${USERNAME:-${USER:-}}"
+    EXTRA_PATHS=(
+      "/c/Program Files/GitHub CLI"
+      "/c/Program Files (x86)/GitHub CLI"
+      "/c/Program Files/jq"
+      "/usr/local/bin"
+      "/mingw64/bin"
+    )
+    if [ -n "$WIN_USER" ]; then
+      EXTRA_PATHS+=(
+        "/c/Users/$WIN_USER/.local/bin"
+        "/c/Users/$WIN_USER/AppData/Local/Programs/claude/bin"
+        "/c/Users/$WIN_USER/AppData/Local/Microsoft/WinGet/Links"
+      )
+    fi
+    for p in "${EXTRA_PATHS[@]}"; do
+      [ -d "$p" ] && PATH="$PATH:$p"
+    done
+    export PATH
+    ;;
+esac
+
 # 1. Check required tools
 echo "Checking required tools..."
 
 MISSING=0
 
+# On Windows, many CLIs are shipped as .exe. Try both the bare name and the
+# .exe variant before giving up.
+find_tool() {
+  local tool=$1
+  if command -v "$tool" &>/dev/null; then
+    command -v "$tool"
+    return 0
+  fi
+  if command -v "$tool.exe" &>/dev/null; then
+    command -v "$tool.exe"
+    return 0
+  fi
+  return 1
+}
+
 check_tool() {
   local tool=$1
   local install_hint=$2
-  if command -v "$tool" &>/dev/null; then
-    ok "$tool found ($(command -v "$tool"))"
+  local found
+  if found=$(find_tool "$tool"); then
+    ok "$tool found ($found)"
   else
     err "$tool not found. $install_hint"
     MISSING=$((MISSING + 1))
@@ -80,7 +123,8 @@ fi
 # 6. Check gh auth
 echo ""
 echo "Checking GitHub CLI authentication..."
-if gh auth status &>/dev/null; then
+GH_BIN="$(find_tool gh || true)"
+if [ -n "$GH_BIN" ] && "$GH_BIN" auth status &>/dev/null; then
   ok "GitHub CLI is authenticated."
 else
   warn "GitHub CLI is not authenticated. Run: gh auth login"


### PR DESCRIPTION
## Summary
- On MSYS/MinGW/Cygwin, augment PATH with common Windows install dirs (`/c/Program Files/GitHub CLI`, `/c/Users/$USER/.local/bin`, `/usr/local/bin`, `/mingw64/bin`, WinGet Links) so tools installed system- or user-wide are visible to Git Bash when `bash scripts/setup.sh` is launched from `cmd.exe`.
- Add a `find_tool` helper that tries both the bare name and the `.exe` variant before reporting a tool missing.
- Use the resolved `gh` binary path for the auth-status check.

## Why
Running `bash scripts/setup.sh` from a Windows terminal inherited a narrow PATH from `cmd.exe` and reported `claude`, `gh`, and `jq` as missing even though all three `.exe` binaries were installed. Linux/macOS behavior is unchanged — the augmentation only runs on MSYS/MinGW/Cygwin.

## Test plan
- [x] `bash scripts/setup.sh` on Windows Git Bash now prints `[OK]` for all 5 required tools.
- [ ] No change required for Linux/macOS users (augmentation is gated by `uname -s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)