### PR TITLE
feat(commands): expose ClaudeMaxPower skills as Claude Code slash commands

### DIFF
--- a/.claude/commands/assemble-team.md
+++ b/.claude/commands/assemble-team.md
@@ -1,0 +1,9 @@
+---
+description: Analyze a project and assemble an optimal agent team — enforces brainstorming/spec gate before implementation for new-project mode.
+argument-hint: --mode <value> [--description <value>] [--goals <value>] [--team-size <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent
+---
+
+Read `skills/assemble-team.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/brainstorming.md
+++ b/.claude/commands/brainstorming.md
@@ -1,0 +1,9 @@
+---
+description: Collaborative design refinement through Socratic questioning before any implementation
+argument-hint: --topic <value> [--visual <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, TaskCreate, TaskUpdate
+---
+
+Read `skills/brainstorming.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/finish-branch.md
+++ b/.claude/commands/finish-branch.md
@@ -1,0 +1,9 @@
+---
+description: Completes development work — verifies tests pass, presents merge/PR/keep/discard options, cleans up worktrees.
+argument-hint: [--base <value>]
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+Read `skills/finish-branch.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,9 @@
+---
+description: Fix a GitHub issue end-to-end — reads the issue, reproduces the bug with a test, fixes the code, and opens a PR.
+argument-hint: --issue <value> [--repo <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+Read `skills/fix-issue.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/generate-docs.md
+++ b/.claude/commands/generate-docs.md
@@ -1,0 +1,9 @@
+---
+description: Auto-generate documentation from source code — extracts public APIs and creates or updates markdown docs.
+argument-hint: --dir <value> [--output <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+Read `skills/generate-docs.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/max-power.md
+++ b/.claude/commands/max-power.md
@@ -1,0 +1,9 @@
+---
+description: One-command activation — installs ClaudeMaxPower, offers Superpowers plugin install, presents capabilities menu, and routes the user to the right skill for their immediate goal.
+argument-hint: [--goal <value>] [--mode <value>] [--install-superpowers-plugin <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, TaskCreate, TaskUpdate
+---
+
+Read `skills/max-power.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/pre-commit.md
+++ b/.claude/commands/pre-commit.md
@@ -1,0 +1,8 @@
+---
+description: Intelligent pre-commit check — inspects staged changes for secrets, style issues, debug statements, and generates a conventional commit message.
+allowed-tools: Bash, Read, Grep
+---
+
+Read `skills/pre-commit.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/refactor-module.md
+++ b/.claude/commands/refactor-module.md
@@ -1,0 +1,9 @@
+---
+description: Safely refactor a module — captures a test baseline first, applies the refactor, then verifies all tests still pass.
+argument-hint: --file <value> --goal <value>
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+Read `skills/refactor-module.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,9 @@
+---
+description: Full PR review — reads the diff, checks for bugs/security/tests/style, and posts a structured review comment via GitHub CLI.
+argument-hint: --pr <value> [--repo <value>]
+allowed-tools: Bash, Read, Grep
+---
+
+Read `skills/review-pr.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/subagent-dev.md
+++ b/.claude/commands/subagent-dev.md
@@ -1,0 +1,9 @@
+---
+description: Execute a plan with a fresh subagent per task and two-stage review (spec then quality)
+argument-hint: --plan <value> [--worktree <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, TaskCreate, TaskUpdate
+---
+
+Read `skills/subagent-dev.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/systematic-debugging.md
+++ b/.claude/commands/systematic-debugging.md
@@ -1,0 +1,9 @@
+---
+description: Four-phase root cause debugging process. Never propose a fix without a failing test and a verified root cause.
+argument-hint: --issue <value> [--file <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+Read `skills/systematic-debugging.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/tdd-loop-lite.md
+++ b/.claude/commands/tdd-loop-lite.md
@@ -1,0 +1,9 @@
+---
+description: Autonomous TDD loop — writes failing tests from a spec, then iterates on implementation until all tests are green. Stops at 10 iterations. Simpler TDD loop with 10-iteration cap — for use cases where the full strict TDD is overkill. For strict TDD with mandatory RED verification and iron-law enforcement, use /tdd-loop.
+argument-hint: --spec <value> --file <value> [--test-file <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+Read `skills/tdd-loop-lite.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/tdd-loop.md
+++ b/.claude/commands/tdd-loop.md
@@ -1,0 +1,9 @@
+---
+description: Strict Test-Driven Development — iron law enforcement, mandatory RED verification, anti-rationalization guardrails. Write the test first, watch it fail, write minimal code to pass.
+argument-hint: --spec <value> --file <value> [--test-file <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+Read `skills/tdd-loop.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/using-worktrees.md
+++ b/.claude/commands/using-worktrees.md
@@ -1,0 +1,9 @@
+---
+description: Creates an isolated git worktree workspace before implementation. Systematic directory selection plus safety verification.
+argument-hint: --branch <value> [--location <value>]
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+Read `skills/using-worktrees.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/writing-plans.md
+++ b/.claude/commands/writing-plans.md
@@ -1,0 +1,9 @@
+---
+description: Break an approved spec into bite-sized, subagent-executable implementation tasks
+argument-hint: --spec <value> [--output <value>]
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, TaskCreate, TaskUpdate
+---
+
+Read `skills/writing-plans.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/scripts/generate-commands.py
+++ b/scripts/generate-commands.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Generate Claude Code slash-command wrappers from skills/*.md.
+
+Claude Code auto-discovers slash commands from .claude/commands/<name>.md.
+ClaudeMaxPower documents skills in skills/*.md (source of truth). This
+script emits one thin wrapper per skill so /name shows up in the / menu
+and, when invoked, tells Claude to follow the canonical skill file.
+
+Run from the project root:
+    python3 scripts/generate-commands.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SKILLS_DIR = Path("skills")
+CMD_DIR = Path(".claude/commands")
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+NAME_RE = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
+DESC_RE = re.compile(r"^description:\s*(.+?)\s*$", re.MULTILINE)
+TOOLS_BLOCK_RE = re.compile(r"^allowed-tools:\s*\n((?:\s*-\s*\S+\s*\n?)+)", re.MULTILINE)
+ARGS_BLOCK_RE = re.compile(r"^arguments:\s*\n((?:\s*-\s*name:.*?\n(?:\s{2,}.*\n)*)+)", re.MULTILINE)
+ARG_ITEM_RE = re.compile(
+    r"-\s*name:\s*(\S+)\s*\n"
+    r"(?:\s+description:\s*.+\n)?"
+    r"(?:\s+required:\s*(true|false)\s*\n)?",
+    re.MULTILINE,
+)
+
+
+def parse_frontmatter(text: str) -> dict:
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    fm = m.group(1)
+    data = {}
+    if (nm := NAME_RE.search(fm)):
+        data["name"] = nm.group(1)
+    if (dm := DESC_RE.search(fm)):
+        data["description"] = dm.group(1).strip().strip('"').strip("'")
+    if (tm := TOOLS_BLOCK_RE.search(fm)):
+        data["tools"] = [
+            line.strip("- \n") for line in tm.group(1).splitlines() if line.strip()
+        ]
+    if (am := ARGS_BLOCK_RE.search(fm)):
+        data["arguments"] = [
+            {"name": n, "required": (req == "true")}
+            for n, req in ARG_ITEM_RE.findall(am.group(1))
+        ]
+    return data
+
+
+def build_argument_hint(args: list[dict]) -> str:
+    parts = []
+    for a in args:
+        token = f"--{a['name']} <value>"
+        parts.append(token if a.get("required") else f"[{token}]")
+    return " ".join(parts)
+
+
+def wrapper_text(skill_name: str, meta: dict) -> str:
+    desc = meta.get("description", f"Run the {skill_name} workflow.")
+    hint = build_argument_hint(meta.get("arguments", []))
+    tools = meta.get("tools", [])
+
+    lines = ["---", f"description: {desc}"]
+    if hint:
+        lines.append(f"argument-hint: {hint}")
+    if tools:
+        lines.append(f"allowed-tools: {', '.join(tools)}")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        f"Read `skills/{skill_name}.md` in this repository and execute its "
+        f"workflow verbatim. Parse any arguments the user passed below and "
+        f"bind them to the skill's declared arguments before running."
+    )
+    lines.append("")
+    lines.append("User arguments: $ARGUMENTS")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if not SKILLS_DIR.is_dir():
+        print(f"error: {SKILLS_DIR}/ not found. Run from project root.", file=sys.stderr)
+        return 1
+
+    CMD_DIR.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for skill_file in sorted(SKILLS_DIR.glob("*.md")):
+        text = skill_file.read_text(encoding="utf-8")
+        meta = parse_frontmatter(text)
+        name = meta.get("name") or skill_file.stem
+        out = CMD_DIR / f"{name}.md"
+        out.write_text(wrapper_text(name, meta), encoding="utf-8")
+        written += 1
+        print(f"  [OK] /{name} -> {out}")
+
+    print(f"\nGenerated {written} slash-command wrappers in {CMD_DIR}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -112,6 +112,19 @@ chmod +x workflows/*.sh
 chmod +x scripts/*.sh
 ok "Workflow scripts are executable."
 
+# 4b. Generate Claude Code slash-command wrappers from skills/*.md
+# Claude Code auto-discovers slash commands from .claude/commands/<name>.md.
+# The wrappers delegate to the canonical skill files in skills/.
+if [ -f "scripts/generate-commands.py" ] && [ -d "skills" ]; then
+  echo ""
+  echo "Generating Claude Code slash-command wrappers..."
+  if python3 scripts/generate-commands.py >/dev/null; then
+    ok "Slash commands generated in .claude/commands/ (restart Claude Code to pick them up)."
+  else
+    warn "Failed to generate slash-command wrappers. Run: python3 scripts/generate-commands.py"
+  fi
+fi
+
 # 5. Install Python dependencies for the todo-app example into a local venv.
 # Using a venv avoids PEP 668 "externally-managed-environment" errors on
 # Debian/Ubuntu/WSL and keeps example deps isolated from the system Python.


### PR DESCRIPTION
## Summary
- Add `scripts/generate-commands.py` that parses each `skills/*.md` frontmatter and emits thin wrappers at `.claude/commands/<name>.md`, giving Claude Code's `/` autocomplete 15 new commands: `/max-power`, `/fix-issue`, `/assemble-team`, `/review-pr`, `/refactor-module`, `/pre-commit`, `/generate-docs`, `/brainstorming`, `/writing-plans`, `/subagent-dev`, `/systematic-debugging`, `/finish-branch`, `/using-worktrees`, `/tdd-loop`, `/tdd-loop-lite`.
- Commit the 15 generated wrappers so cloners get working slash commands on first open (no need to run the generator first).
- Call the generator from `scripts/setup.sh` so re-runs keep wrappers in sync with the skill source files.

## Why
Users reported `/max-power`, `/fix-issue`, etc. not appearing in the Claude Code `/` menu. Root cause: Claude Code only discovers slash commands from `.claude/commands/*.md`, but ClaudeMaxPower documents skills in `skills/*.md`. Generating thin wrappers bridges the two without duplicating content — the skill file in `skills/` remains the single source of truth, and each wrapper simply directs Claude to read and follow it.

## Test plan
- [x] `python3 scripts/generate-commands.py` writes 15 wrappers, all valid markdown with frontmatter (`description`, `argument-hint`, `allowed-tools`).
- [x] `bash scripts/setup.sh` runs the generator and reports `[OK] Slash commands generated`.
- [ ] After merging and restarting Claude Code, `/` autocomplete shows all 15 ClaudeMaxPower commands alongside the superpowers plugin skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)