### PR TITLE
fix(ci): resolve shellcheck violations and harden lint pipeline

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,57 @@
+{
+  "name": "main branch protection",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Validate Shell Scripts" },
+          { "context": "Validate GitHub Actions Workflows" },
+          { "context": "Validate JSON Files" },
+          { "context": "Check for Secrets" },
+          { "context": "Lint Markdown" },
+          { "context": "Run Example Tests" },
+          { "context": "Verify Project Structure" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,15 @@ jobs:
     name: Validate Shell Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
+      - name: Install shellcheck v0.10.0
+        run: |
+          curl -fsSL https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz \
+            | tar -xJ
+          sudo mv shellcheck-v0.10.0/shellcheck /usr/local/bin/shellcheck
+          rm -rf shellcheck-v0.10.0
+          shellcheck --version
 
       - name: Lint hook scripts
         run: shellcheck .claude/hooks/*.sh
@@ -25,11 +30,25 @@ jobs:
       - name: Lint setup scripts
         run: shellcheck scripts/*.sh
 
+  validate-actions:
+    name: Validate GitHub Actions Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install actionlint v1.7.7
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+          ./actionlint -version
+
+      - name: Lint workflow YAML
+        run: ./actionlint -color
+
   validate-json:
     name: Validate JSON Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate settings.json
         run: jq empty .claude/settings.json
@@ -43,7 +62,7 @@ jobs:
     name: Check for Secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Ensure .env.example has no real secrets
         run: |
@@ -68,7 +87,7 @@ jobs:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
@@ -89,7 +108,7 @@ jobs:
     name: Run Example Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -114,7 +133,7 @@ jobs:
     name: Verify Project Structure
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check required files exist
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get tag version
         id: tag
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Run CI checks
         run: |
@@ -46,9 +46,11 @@ jobs:
             CHANGES=$(git log --oneline --pretty=format:"- %s (%h)" | head -20)
           fi
 
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "changes<<EOF"
+            echo "$CHANGES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create release archive
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for changelog
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,42 @@ optional Superpowers plugin, run setup, and present the pipeline menu.
 
 ---
 
+## Post-clone setup (manual, one-time)
+
+A few things live in GitHub repository settings rather than in the codebase, so `git clone`
+cannot copy them. Do these once per repo right after cloning the template:
+
+### 1. Import the branch protection ruleset
+
+The repo ships with a ready-made ruleset at
+[`.github/rulesets/main.json`](.github/rulesets/main.json) that:
+
+- Requires all 7 CI jobs to pass before merging to `main`
+- Blocks direct pushes, force-pushes, branch deletion
+- Requires linear history (squash or rebase merges only)
+- Requires PRs even for the repo owner (so CI always gates merges)
+- Allows the **Admin** role (`actor_id: 5`) to bypass in emergencies — adjust if you want
+  stricter, or delete the `bypass_actors` array entirely
+
+To apply it:
+
+1. Go to **Settings → Rules → Rulesets**
+2. **New ruleset → Import a ruleset**
+3. Select `.github/rulesets/main.json`
+4. Review the populated form and click **Create**
+
+If you ever rename a job in `.github/workflows/ci.yml`, update the matching
+`required_status_checks.context` value in the ruleset and re-import — otherwise the renamed
+job will block every merge as a "waiting" required check.
+
+### 2. (Optional) Repository secrets
+
+Skills like `/fix-issue` and `/review-pr` need a GitHub token at runtime; the
+batch workflows additionally need an `ANTHROPIC_API_KEY`. Local use reads these from `.env`.
+For CI / GitHub Actions runs, add them under **Settings → Secrets and variables → Actions**.
+
+---
+
 ## What's Inside
 
 ```

--- a/scripts/auto-dream.sh
+++ b/scripts/auto-dream.sh
@@ -29,6 +29,7 @@ log_ok()    { echo -e "${GREEN}[AutoDream]${NC} $1"; }
 log_warn()  { echo -e "${YELLOW}[AutoDream]${NC} $1"; }
 log_error() { echo -e "${RED}[AutoDream]${NC} $1"; }
 
+# shellcheck disable=SC2317  # invoked indirectly via `trap cleanup EXIT` below
 cleanup() {
     rm -f "$LOCK_FILE" 2>/dev/null || true
 }
@@ -72,8 +73,8 @@ echo $$ > "$LOCK_FILE"
 now_epoch=$(date +%s)
 
 if [ -f "$STATE_FILE" ]; then
-    last_dream_epoch=$(cat "$STATE_FILE" | grep -o '"last_dream_epoch":[0-9]*' | grep -o '[0-9]*' || echo "0")
-    sessions_since=$(cat "$STATE_FILE" | grep -o '"sessions_since":[0-9]*' | grep -o '[0-9]*' || echo "0")
+    last_dream_epoch=$(grep -o '"last_dream_epoch":[0-9]*' "$STATE_FILE" | grep -o '[0-9]*' || echo "0")
+    sessions_since=$(grep -o '"sessions_since":[0-9]*' "$STATE_FILE" | grep -o '[0-9]*' || echo "0")
 else
     last_dream_epoch=0
     sessions_since=0
@@ -189,7 +190,7 @@ done
     for type in "user" "feedback" "project" "reference" "uncategorized"; do
         if [ -n "${type_files[$type]:-}" ]; then
             # Capitalize first letter
-            header=$(echo "$type" | sed 's/^./\U&/')
+            header="${type^}"
             echo "## ${header}"
             echo -e "${type_files[$type]}"
         fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -137,7 +137,7 @@ if [ -f "examples/todo-app/requirements.txt" ]; then
 
   if [ ! -d "$VENV_DIR" ]; then
     if ! python3 -m venv "$VENV_DIR" 2>/tmp/cmp-venv-err; then
-      warn "python3 -m venv failed: $(cat /tmp/cmp-venv-err 2>/dev/null | head -1)"
+      warn "python3 -m venv failed: $(head -1 /tmp/cmp-venv-err 2>/dev/null)"
       warn "On Debian/Ubuntu/WSL run:  sudo apt install -y python3-venv python3-full"
       warn "Skipping example dependencies — re-run scripts/setup.sh after installing."
       VENV_DIR=""

--- a/workflows/batch-fix.sh
+++ b/workflows/batch-fix.sh
@@ -13,12 +13,16 @@ set -euo pipefail
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
-YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
 # Load env
-[ -f .env ] && export $(grep -v '^#' .env | xargs 2>/dev/null) || true
+if [ -f .env ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . ./.env
+  set +a
+fi
 
 REPO="${1:-}"
 shift || true

--- a/workflows/mass-refactor.sh
+++ b/workflows/mass-refactor.sh
@@ -17,7 +17,12 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-[ -f .env ] && export $(grep -v '^#' .env | xargs 2>/dev/null) || true
+if [ -f .env ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . ./.env
+  set +a
+fi
 
 PATTERN=""
 GOAL=""
@@ -60,7 +65,7 @@ fi
 
 FILE_COUNT=$(echo "$MATCHING_FILES" | wc -l)
 echo -e "${GREEN}Found $FILE_COUNT file(s):${NC}"
-echo "$MATCHING_FILES" | sed 's/^/  /'
+echo "  ${MATCHING_FILES//$'\n'/$'\n  '}"
 echo ""
 
 # Safety check for large refactors


### PR DESCRIPTION
## Summary

CI has been red since v1.0 because three lint steps (`shellcheck workflows/*.sh`, `shellcheck scripts/*.sh`) were never green and no branch protection enforced them. This PR makes CI green and adds guardrails so silent regressions don't recur.

## What changed

**Real bug fixes**
- `workflows/batch-fix.sh:21` and `workflows/mass-refactor.sh:20` — SC2046 word-splitting in `.env` loading. Replaced `export $(grep -v '^#' .env | xargs)` with `set -a; . ./.env; set +a`.
  - **Behavior note:** `.env` is now sourced as shell. Quoted values with spaces (`FOO="hello world"`) work correctly where they previously word-split. Unquoted values with spaces (`FOO=hello world`) will now be a parse error instead of being silently truncated to `FOO=hello`. For typical `.env` files (`KEY=token`, `KEY="value with spaces"`) this is strictly more correct.

**Tidy fixes (style violations)**
- `workflows/batch-fix.sh:16` — drop unused `YELLOW`.
- `workflows/mass-refactor.sh:63` — `sed` indent → parameter expansion.
- `scripts/auto-dream.sh:75-76` — drop useless `cat | grep`.
- `scripts/auto-dream.sh:192` — `${type^}` instead of `sed 's/^./\U&/'`.
- `scripts/setup.sh:140` — drop useless `cat | head`.

**One justified suppression**
- `scripts/auto-dream.sh:33` — `# shellcheck disable=SC2317` on `cleanup()` (genuine false positive: function is invoked indirectly via `trap cleanup EXIT`).

**CI hardening**
- Pin `shellcheck` to **v0.10.0** in CI (was: `apt-get install shellcheck` on `ubuntu-latest`, which silently bumped to 0.9.0+ when the runner moved to Ubuntu 24.04 and started firing SC2317).
- New `validate-actions` job running **actionlint v1.7.7** to catch workflow YAML errors and deprecated action versions proactively.
- Bump `actions/checkout@v4` → `@v5` in both `ci.yml` and `release.yml` (Node 20 deprecation warning).

## Test plan

Verified locally on Windows/Git Bash with the same pinned tool versions CI will use:

- [x] `shellcheck .claude/hooks/*.sh` → exit 0
- [x] `shellcheck workflows/*.sh` → exit 0 (was: exit 1 on `main`)
- [x] `shellcheck scripts/*.sh` → exit 0 (was: exit 1 on `main`)
- [x] `actionlint` on all `.github/workflows/*.yml` → exit 0
- [ ] CI run on this PR (will be visible after push)

## Follow-up (not in this PR)

The single highest-impact change is **out of band**: enable branch protection on `main` requiring the CI check to pass. Without it, the next red CI will pile up the same way. Settings → Branches → Add rule for `main` → "Require status checks to pass" → select `CI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)