### PR TITLE
docs(sentry): clarify Sentry MCP setup and DSN-vs-token distinction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,16 @@
 # Scopes needed: repo, read:org
 GITHUB_TOKEN=ghp_your_token_here
 
-# Sentry Integration
-# Required for: MCP Sentry integration
+# Sentry MCP Integration (OPTIONAL)
+# Only required if you enable the Sentry MCP server in .claude/settings.json.
+# This lets Claude read your Sentry errors during a session — it does NOT send
+# the template's own runtime errors to Sentry (no SDK is initialized here).
+#
+# SENTRY_TOKEN is a Sentry *auth token* (management API), NOT a DSN.
+#   - Create one at:  https://sentry.io/settings/account/api/auth-tokens/
+#   - Required scopes: project:read, event:read, org:read
+# SENTRY_ORG / SENTRY_PROJECT are the slugs visible in your Sentry URLs
+#   (e.g. https://sentry.io/organizations/<SENTRY_ORG>/projects/<SENTRY_PROJECT>/).
 SENTRY_TOKEN=your_sentry_auth_token_here
 SENTRY_ORG=your-org-slug
 SENTRY_PROJECT=your-project-slug

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,10 @@ Required for full functionality:
 - `DEFAULT_REPO` — your default repository in `owner/repo` format
 
 Optional:
-- `SENTRY_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` — for Sentry MCP integration
+- `SENTRY_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` — for the Sentry MCP integration
+  (Claude reads your Sentry errors during a session). `SENTRY_TOKEN` is a Sentry
+  *auth token*, not a DSN. See [`mcp/README.md`](../mcp/README.md#step-1-configure-your-secrets)
+  for token-creation steps and required scopes.
 
 ### 4. Verify everything is working
 

--- a/docs/mcp-integrations.md
+++ b/docs/mcp-integrations.md
@@ -46,10 +46,17 @@ What open issues are labeled "bug" in this repo?
 ```
 Claude lists them with titles and descriptions.
 
-## Sentry Integration
+## Sentry Integration  *(optional)*
 
 **Config:** `mcp/sentry-config.json`
 **Requires:** `SENTRY_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
+
+> **`SENTRY_TOKEN` is a Sentry auth token, not a DSN.** A DSN is a write credential
+> used by SDKs that *send* errors to Sentry. This integration is read-only: Claude
+> queries your Sentry project's events through the management API. If you paste a DSN
+> into `SENTRY_TOKEN`, the MCP server will fail to authenticate. Create an auth token
+> at [sentry.io/settings/account/api/auth-tokens/](https://sentry.io/settings/account/api/auth-tokens/)
+> with scopes `project:read`, `event:read`, `org:read`.
 
 ### What Claude can do with Sentry MCP
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,26 +8,37 @@ MCP allows Claude Code to directly query real-world tools — GitHub issues, Sen
 
 ## Available Integrations
 
-| Integration | Config File | What It Enables |
-|------------|-------------|-----------------|
-| GitHub | `github-config.json` | Read issues, PRs, code, create comments |
-| Sentry | `sentry-config.json` | Query error events, stack traces, releases |
+| Integration | Config File | Required? | What It Enables |
+|------------|-------------|-----------|-----------------|
+| GitHub | `github-config.json` | Recommended | Read issues, PRs, code, create comments |
+| Sentry | `sentry-config.json` | **Optional** | Query error events, stack traces, releases |
+
+> **Sentry is opt-in.** Nothing in this template initializes the Sentry SDK or sends
+> errors to Sentry from your machine. The Sentry MCP server is a one-way data path —
+> *Claude reads from your Sentry project*, nothing in the template writes to it.
 
 ## Setup
 
 ### Step 1: Configure your secrets
 
-Add the required values to `.env`:
+Add the required values to `.env` (create from `.env.example` if you haven't already):
 
 ```bash
-# GitHub
+# GitHub  (recommended)
 GITHUB_TOKEN=ghp_your_token_here
 
-# Sentry
-SENTRY_TOKEN=your_sentry_auth_token
+# Sentry  (optional — only needed if you enable the Sentry MCP server below)
+SENTRY_TOKEN=your_sentry_auth_token   # Sentry auth token, NOT a DSN
 SENTRY_ORG=your-org-slug
 SENTRY_PROJECT=your-project-slug
 ```
+
+**About `SENTRY_TOKEN`:** this is a Sentry *auth token* (management API credential)
+— not a DSN. DSNs are for SDKs that *send* errors; this template doesn't ship an
+SDK. Create an auth token at
+[sentry.io/settings/account/api/auth-tokens/](https://sentry.io/settings/account/api/auth-tokens/)
+with scopes `project:read`, `event:read`, `org:read`. Use a fine-grained token
+scoped to the single project you want Claude to see.
 
 ### Step 2: Merge MCP config into Claude settings
 
@@ -90,9 +101,31 @@ With Sentry MCP connected, Claude can:
 **Example prompt with Sentry MCP:**
 > "Check the latest Sentry errors in the production environment and fix the most frequent one."
 
+### Sentry MCP — What this is NOT
+
+This integration is the **Claude → Sentry read path**. It is not an error reporter.
+
+- It does **not** initialize the Sentry SDK in your project.
+- It does **not** send errors from this template (or its example app) to Sentry.
+- It does **not** require a DSN.
+
+If you also want runtime error reporting from your own app, install and configure
+the appropriate Sentry SDK in *that* application — not in the template root. Read
+the DSN from `os.environ["SENTRY_DSN"]` (or the framework equivalent), keep init
+conditional on the env var being set, and never commit a DSN to source.
+
 ## Security Notes
 
 - `.env` is in `.gitignore` — never commit real tokens
 - MCP servers run as child processes with only the env vars you provide
 - The GitHub token only needs `repo` and `read:org` scopes for most operations
-- Rotate tokens regularly and use fine-grained tokens when possible
+- Use fine-grained tokens (project-scoped for Sentry, repo-scoped for GitHub) when possible
+- Rotate tokens regularly
+- **Sentry: token, not DSN.** A DSN identifies a project for *write* access (sending
+  errors). The MCP server uses an *auth token* for *read* access. Don't paste your DSN
+  into `SENTRY_TOKEN` — it won't work and it's a different secret with different
+  rotation requirements.
+- **`npx -y` always pulls the latest version** of an MCP server package on each launch.
+  That's convenient but means upstream updates are applied without review. For
+  production use, pin a specific version (`npx -y mcp-server-sentry@<version>`) or
+  install the package globally and reference it by absolute path.


### PR DESCRIPTION
## Summary

Triggered by a paste of Sentry's Python SDK onboarding (with a real DSN) into a session — nothing in the template needed to change architecturally (MCP approach was already correct, no DSN was ever committed), but the docs didn't draw the SDK-vs-MCP and DSN-vs-auth-token distinctions explicitly. This PR fixes that.

**No code or config changes.** Documentation only.

## What changed

- **`.env.example`** — Sentry section now has a header that:
  - Marks it as **optional**
  - States it's a one-way **read** path (Claude reads Sentry; nothing writes to Sentry)
  - Says `SENTRY_TOKEN` is an *auth token*, **not a DSN**
  - Links to [sentry.io/settings/account/api/auth-tokens/](https://sentry.io/settings/account/api/auth-tokens/)
  - Lists required scopes: `project:read`, `event:read`, `org:read`
- **`mcp/README.md`** — adds:
  - "Required?" column to the integrations table (Sentry: **Optional**)
  - Same DSN/token clarification under Step 1
  - New **"Sentry MCP — What this is NOT"** block explicitly listing what the template does not do (no SDK, no DSN, no error reporting from this template)
  - Security note about `npx -y` always pulling the latest MCP server version (pin in production)
- **`docs/mcp-integrations.md`** — Sentry section marked optional + DSN/token distinction inline
- **`docs/getting-started.md`** — cross-links to `mcp/README.md` for the token-creation walkthrough

## Audit results (no changes needed)

- `mcp/sentry-config.json` — already uses `${SENTRY_TOKEN}` env interpolation; no hardcoded values
- No DSN found anywhere in the repo (now or historically)
- No example code initializes the Sentry SDK
- Placeholder strings in `.env.example` still match the substring greps in `scripts/verify.sh:50` and `.claude/hooks/session-start.sh:49`, so the unfilled-placeholder warning continues to fire correctly

## Test plan

- [x] `jq empty mcp/sentry-config.json` → valid
- [x] `jq empty mcp/github-config.json` → valid
- [x] `shellcheck` on all three sets → exit 0
- [x] `actionlint` on workflows → exit 0
- [x] Placeholder strings in `.env.example` still match the greps in `verify.sh` + `session-start.sh`
- [ ] CI run on this PR (will be visible after push)

## Follow-ups (not in this PR)

1. **Pin `mcp-server-sentry` version** in `mcp/sentry-config.json` (currently `npx -y mcp-server-sentry`, which always pulls latest). Pinning closes a supply-chain risk.
2. **Consider Sentry's official remote MCP server** (`https://mcp.sentry.dev/sse`, OAuth-based) as an alternative to the npm package. Different auth model, different trust profile — worth evaluating but out of scope here.
3. **Verify the npm package source** of `mcp-server-sentry` once and document the maintainer in `mcp/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)