### PR TITLE
fix(mcp): replace broken Sentry npm package with official remote OAuth MCP

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -46,7 +46,7 @@ echo ""
 if [ -f ".env" ]; then
   echo -e "${GREEN}.env file found.${NC}"
   # Check for unfilled placeholders
-  if grep -q "your_token_here\|your_sentry_auth_token\|your-org-slug\|your-username" .env 2>/dev/null; then
+  if grep -q "your_token_here\|your-username/your-repo" .env 2>/dev/null; then
     echo -e "${YELLOW}Warning: .env has unfilled placeholder values. Update before using integrations.${NC}"
   fi
 else

--- a/.env.example
+++ b/.env.example
@@ -7,19 +7,21 @@
 # Scopes needed: repo, read:org
 GITHUB_TOKEN=ghp_your_token_here
 
-# Sentry MCP Integration (OPTIONAL)
-# Only required if you enable the Sentry MCP server in .claude/settings.json.
-# This lets Claude read your Sentry errors during a session — it does NOT send
-# the template's own runtime errors to Sentry (no SDK is initialized here).
+# Sentry MCP Integration
+# The default integration uses Sentry's official remote MCP server with OAuth
+# (https://mcp.sentry.dev/mcp). OAuth is handled by Claude Code on first /mcp
+# invocation — NO env vars are required for the default path.
 #
-# SENTRY_TOKEN is a Sentry *auth token* (management API), NOT a DSN.
-#   - Create one at:  https://sentry.io/settings/account/api/auth-tokens/
-#   - Required scopes: project:read, event:read, org:read
-# SENTRY_ORG / SENTRY_PROJECT are the slugs visible in your Sentry URLs
-#   (e.g. https://sentry.io/organizations/<SENTRY_ORG>/projects/<SENTRY_PROJECT>/).
-SENTRY_TOKEN=your_sentry_auth_token_here
-SENTRY_ORG=your-org-slug
-SENTRY_PROJECT=your-project-slug
+# The variables below are only needed if you run the SELF-HOSTED stdio variant
+# (@sentry/mcp-server) against a self-hosted Sentry instance. See mcp/README.md
+# for setup. Leave blank if you use the default remote OAuth path.
+#
+# SENTRY_ACCESS_TOKEN — Sentry user auth token (NOT a DSN). Create one at
+#   https://sentry.io/settings/account/api/auth-tokens/ with scopes:
+#   org:read, project:read, project:write, team:read, team:write, event:write
+# SENTRY_HOST — base URL of your self-hosted Sentry (e.g. https://sentry.example.com)
+# SENTRY_ACCESS_TOKEN=
+# SENTRY_HOST=
 
 # Database (optional — for DB-to-UI workflow examples)
 DB_URL=postgresql://user:password@localhost:5432/mydb

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,10 +48,12 @@ Required for full functionality:
 - `DEFAULT_REPO` — your default repository in `owner/repo` format
 
 Optional:
-- `SENTRY_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` — for the Sentry MCP integration
-  (Claude reads your Sentry errors during a session). `SENTRY_TOKEN` is a Sentry
-  *auth token*, not a DSN. See [`mcp/README.md`](../mcp/README.md#step-1-configure-your-secrets)
-  for token-creation steps and required scopes.
+- The Sentry MCP integration (Claude reads your Sentry errors during a session)
+  uses the official remote OAuth endpoint by default and needs **no env vars** —
+  authentication is handled by Claude Code on first `/mcp` call. If you run
+  self-hosted Sentry, see [`mcp/README.md`](../mcp/README.md#sentry-mcp--self-hosted-advanced-optional)
+  for the stdio-based alternative and the env vars it needs
+  (`SENTRY_ACCESS_TOKEN`, `SENTRY_HOST`).
 
 ### 4. Verify everything is working
 

--- a/docs/mcp-integrations.md
+++ b/docs/mcp-integrations.md
@@ -48,15 +48,27 @@ Claude lists them with titles and descriptions.
 
 ## Sentry Integration  *(optional)*
 
-**Config:** `mcp/sentry-config.json`
-**Requires:** `SENTRY_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
+**Default config:** `mcp/sentry-config.json` — Sentry's official remote MCP server
+at `https://mcp.sentry.dev/mcp`, OAuth-authenticated.
+**Requires (default path):** nothing in `.env`. OAuth happens on first `/mcp` call.
 
-> **`SENTRY_TOKEN` is a Sentry auth token, not a DSN.** A DSN is a write credential
-> used by SDKs that *send* errors to Sentry. This integration is read-only: Claude
-> queries your Sentry project's events through the management API. If you paste a DSN
-> into `SENTRY_TOKEN`, the MCP server will fail to authenticate. Create an auth token
-> at [sentry.io/settings/account/api/auth-tokens/](https://sentry.io/settings/account/api/auth-tokens/)
-> with scopes `project:read`, `event:read`, `org:read`.
+Add it with one command:
+
+```bash
+claude mcp add --transport http sentry https://mcp.sentry.dev/mcp
+```
+
+Then restart Claude Code, run `/mcp`, click the OAuth link, authorize.
+
+> **The default path is for hosted Sentry only** (`sentry.io`). If you run a
+> self-hosted Sentry, see [`mcp/README.md`](../mcp/README.md#sentry-mcp--self-hosted-advanced-optional)
+> for the stdio-based alternative using `@sentry/mcp-server`.
+
+> **Token vs DSN — read this if you've used Sentry SDKs before.** A DSN is a *write*
+> credential used by SDKs that *send* errors to Sentry. The MCP integration is
+> *read-only*: Claude queries your project's events. The default remote path uses
+> OAuth, so neither a DSN nor a token is required. The self-hosted path uses a
+> Sentry *user auth token* (`SENTRY_ACCESS_TOKEN`), which is also not a DSN.
 
 ### What Claude can do with Sentry MCP
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -131,11 +131,27 @@ cat .claude/settings.json | jq '.mcpServers'
 npx -y @modelcontextprotocol/server-github --help 2>&1 | head -5
 ```
 
-**Check 3: Token is valid**
+**Check 3: GitHub token is valid**
 ```bash
 source .env
 curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user
 ```
+
+**Check 4: Sentry remote MCP — re-run OAuth**
+
+The Sentry default integration uses OAuth, not a token. If `/mcp` shows `sentry`
+as failed or never authenticated, re-run the auth flow:
+```
+/mcp
+```
+Click the auth link next to `sentry`. If the link doesn't appear, try removing
+and re-adding the server:
+```bash
+claude mcp remove sentry
+claude mcp add --transport http sentry https://mcp.sentry.dev/mcp
+```
+You can revoke previously-granted access at
+[sentry.io/settings/account/api/authorized-applications/](https://sentry.io/settings/account/api/authorized-applications/).
 
 ---
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -19,34 +19,35 @@ MCP allows Claude Code to directly query real-world tools — GitHub issues, Sen
 
 ## Setup
 
-### Step 1: Configure your secrets
+### Step 1: Configure GitHub credentials
 
-Add the required values to `.env` (create from `.env.example` if you haven't already):
+Add to `.env` (create from `.env.example` if you haven't already):
 
 ```bash
-# GitHub  (recommended)
 GITHUB_TOKEN=ghp_your_token_here
-
-# Sentry  (optional — only needed if you enable the Sentry MCP server below)
-SENTRY_TOKEN=your_sentry_auth_token   # Sentry auth token, NOT a DSN
-SENTRY_ORG=your-org-slug
-SENTRY_PROJECT=your-project-slug
 ```
 
-**About `SENTRY_TOKEN`:** this is a Sentry *auth token* (management API credential)
-— not a DSN. DSNs are for SDKs that *send* errors; this template doesn't ship an
-SDK. Create an auth token at
-[sentry.io/settings/account/api/auth-tokens/](https://sentry.io/settings/account/api/auth-tokens/)
-with scopes `project:read`, `event:read`, `org:read`. Use a fine-grained token
-scoped to the single project you want Claude to see.
+The Sentry default path uses OAuth — no env vars needed.
 
-### Step 2: Merge MCP config into Claude settings
+### Step 2: Add MCP servers to Claude Code
 
-Add the MCP servers to `.claude/settings.json`. Merge `github-config.json` and/or `sentry-config.json` into the existing settings file:
+The fastest path is the `claude mcp add` CLI:
+
+```bash
+# GitHub (stdio, npm package, token auth)
+claude mcp add --transport stdio github \
+  --env GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_TOKEN \
+  -- npx -y @modelcontextprotocol/server-github
+
+# Sentry (remote, OAuth — official Sentry-hosted endpoint)
+claude mcp add --transport http sentry https://mcp.sentry.dev/mcp
+```
+
+Or merge the JSON snippets from `github-config.json` and `sentry-config.json`
+into your `.claude/settings.json` under `mcpServers`:
 
 ```json
 {
-  "hooks": { ... },
   "mcpServers": {
     "github": {
       "command": "npx",
@@ -56,26 +57,23 @@ Add the MCP servers to `.claude/settings.json`. Merge `github-config.json` and/o
       }
     },
     "sentry": {
-      "command": "npx",
-      "args": ["-y", "mcp-server-sentry"],
-      "env": {
-        "SENTRY_AUTH_TOKEN": "${SENTRY_TOKEN}",
-        "SENTRY_ORG": "${SENTRY_ORG}",
-        "SENTRY_PROJECT": "${SENTRY_PROJECT}"
-      }
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
     }
   }
 }
 ```
 
-### Step 3: Verify
+### Step 3: Verify and authenticate
 
-Restart Claude Code and verify MCP tools are available:
+Restart Claude Code and run:
 ```
 /mcp
 ```
 
-You should see `github` and/or `sentry` listed as connected servers.
+`github` should connect immediately using your token. `sentry` will appear with
+a link to authenticate via OAuth in your browser — click it, log in to Sentry,
+authorize the connection. Subsequent sessions reuse the OAuth token automatically.
 
 ## GitHub MCP — What You Can Do
 
@@ -101,6 +99,10 @@ With Sentry MCP connected, Claude can:
 **Example prompt with Sentry MCP:**
 > "Check the latest Sentry errors in the production environment and fix the most frequent one."
 
+The org and project to query are supplied per-prompt — there are no `SENTRY_ORG`
+or `SENTRY_PROJECT` env vars in the default path. Claude infers them from your
+OAuth-authorized scope plus what you mention in the prompt.
+
 ### Sentry MCP — What this is NOT
 
 This integration is the **Claude → Sentry read path**. It is not an error reporter.
@@ -114,18 +116,60 @@ the appropriate Sentry SDK in *that* application — not in the template root. R
 the DSN from `os.environ["SENTRY_DSN"]` (or the framework equivalent), keep init
 conditional on the env var being set, and never commit a DSN to source.
 
+### Sentry MCP — Self-hosted (advanced, optional)
+
+If you run a self-hosted Sentry instance, the remote OAuth endpoint
+(`mcp.sentry.dev`) won't reach it. Switch to the official **stdio** server,
+which runs locally and talks to your Sentry over HTTPS:
+
+1. In `.env`, set:
+   ```bash
+   SENTRY_ACCESS_TOKEN=<your self-hosted Sentry user auth token>
+   SENTRY_HOST=https://sentry.example.com
+   ```
+   Required token scopes: `org:read`, `project:read`, `project:write`,
+   `team:read`, `team:write`, `event:write`. Note these are *broader* than
+   read-only — review whether that's acceptable for your environment.
+
+2. Replace the `sentry` block in `.claude/settings.json` with the stdio shape:
+   ```json
+   {
+     "mcpServers": {
+       "sentry": {
+         "command": "npx",
+         "args": ["-y", "@sentry/mcp-server@0.32.0"],
+         "env": {
+           "SENTRY_ACCESS_TOKEN": "${SENTRY_ACCESS_TOKEN}",
+           "SENTRY_HOST": "${SENTRY_HOST}"
+         }
+       }
+     }
+   }
+   ```
+   `@sentry/mcp-server` is the official Sentry-maintained npm package
+   ([getsentry/sentry-mcp](https://github.com/getsentry/sentry-mcp)). Pin a
+   specific version (the example uses `0.32.0`) rather than `@latest` for
+   reproducible installs.
+
+3. Restart Claude Code and run `/mcp` to verify.
+
+This path is unrelated to OAuth — auth is done via the access token.
+
 ## Security Notes
 
 - `.env` is in `.gitignore` — never commit real tokens
-- MCP servers run as child processes with only the env vars you provide
+- MCP servers run as child processes (stdio) or make network calls (http/sse) with
+  only the credentials you explicitly provide
 - The GitHub token only needs `repo` and `read:org` scopes for most operations
-- Use fine-grained tokens (project-scoped for Sentry, repo-scoped for GitHub) when possible
-- Rotate tokens regularly
-- **Sentry: token, not DSN.** A DSN identifies a project for *write* access (sending
-  errors). The MCP server uses an *auth token* for *read* access. Don't paste your DSN
-  into `SENTRY_TOKEN` — it won't work and it's a different secret with different
-  rotation requirements.
-- **`npx -y` always pulls the latest version** of an MCP server package on each launch.
-  That's convenient but means upstream updates are applied without review. For
-  production use, pin a specific version (`npx -y mcp-server-sentry@<version>`) or
-  install the package globally and reference it by absolute path.
+- Use fine-grained tokens (repo-scoped for GitHub, project-scoped for self-hosted
+  Sentry) when possible; rotate them regularly
+- **Sentry default path (remote OAuth):** no long-lived secret lives in `.env`.
+  The OAuth token is stored by Claude Code and can be revoked from
+  [sentry.io/settings/account/api/authorized-applications/](https://sentry.io/settings/account/api/authorized-applications/)
+- **Sentry self-hosted path:** `SENTRY_ACCESS_TOKEN` is a Sentry *user auth token*,
+  not a DSN. A DSN is a write credential used by SDKs that *send* errors. Don't
+  paste a DSN here — it won't authenticate.
+- **`npx -y` always pulls the latest version** of an npm MCP server package. For
+  self-hosted Sentry and for GitHub, pin a specific version
+  (`@sentry/mcp-server@0.32.0`, `@modelcontextprotocol/server-github@<version>`)
+  rather than relying on `latest`.

--- a/mcp/sentry-config.json
+++ b/mcp/sentry-config.json
@@ -1,13 +1,8 @@
 {
   "mcpServers": {
     "sentry": {
-      "command": "npx",
-      "args": ["-y", "mcp-server-sentry"],
-      "env": {
-        "SENTRY_AUTH_TOKEN": "${SENTRY_TOKEN}",
-        "SENTRY_ORG": "${SENTRY_ORG}",
-        "SENTRY_PROJECT": "${SENTRY_PROJECT}"
-      }
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
     }
   }
 }

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -47,7 +47,7 @@ done
 section "Environment"
 if [ -f ".env" ]; then
   ok ".env file exists"
-  if grep -q "your_token_here\|your_sentry_auth_token\|your-org-slug" .env; then
+  if grep -q "your_token_here\|your-username/your-repo" .env; then
     warn ".env has unfilled placeholder values — update before using integrations"
   else
     ok ".env appears to be configured"


### PR DESCRIPTION
## Summary

PR #5 documented the Sentry MCP integration more clearly but didn't fix the underlying problem: `mcp/sentry-config.json` referenced `mcp-server-sentry`, which **returns 404 on the npm registry** and almost certainly never existed. The integration has been silently broken since v1.0. This PR fixes it by switching the default to Sentry's official remote MCP server with OAuth.

## What was broken

- `mcp/sentry-config.json` ran `npx -y mcp-server-sentry` — package not on npm
- All env vars (`SENTRY_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`) flowed into a process that couldn't start
- Docs in PR #5 explained the wrong-package setup more clearly but still wrongly

## What was replaced

The default Sentry MCP integration now uses Sentry's **official remote OAuth endpoint**, documented by Claude Code itself ([code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp)):

```bash
claude mcp add --transport http sentry https://mcp.sentry.dev/mcp
```

Or in `.claude/settings.json`:

```json
{
  "mcpServers": {
    "sentry": {
      "type": "http",
      "url": "https://mcp.sentry.dev/mcp"
    }
  }
}
```

OAuth is handled by Claude Code on first `/mcp` call — no long-lived secret in `.env`.

## Env vars: removed, renamed, no longer needed

**Default path — removed entirely (no env vars needed):**
- `SENTRY_TOKEN` — gone (OAuth replaces it)
- `SENTRY_ORG` — gone (org inferred from OAuth scope; supplied per-prompt)
- `SENTRY_PROJECT` — gone (same)

**Self-hosted path — new, opt-in (commented out in `.env.example`):**
- `SENTRY_ACCESS_TOKEN` — Sentry user auth token (NOT a DSN)
- `SENTRY_HOST` — base URL of self-hosted Sentry instance

Existing `.env` files with the old `SENTRY_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` keep working as orphaned (unused) entries. Nothing breaks for existing users.

## Self-hosted Sentry — still supported

Self-hosted Sentry users can't reach `mcp.sentry.dev`, so they get a clearly-labeled **"Sentry MCP — Self-hosted (advanced, optional)"** section in `mcp/README.md` describing the stdio alternative:

- Uses `@sentry/mcp-server@0.32.0` (the official Sentry-maintained npm package, [getsentry/sentry-mcp](https://github.com/getsentry/sentry-mcp), maintained by Sentry core engineers including mitsuhiko, billyvg, evanpurkhiser)
- Pinned version (no `latest`) for reproducibility
- Required scopes documented: `org:read`, `project:read`, `project:write`, `team:read`, `team:write`, `event:write` — note these are *broader* than read-only and that's called out in the docs

## Files changed

| File | Change |
|---|---|
| `mcp/sentry-config.json` | stdio shape → `{"type":"http","url":"https://mcp.sentry.dev/mcp"}` |
| `mcp/README.md` | Sentry section rewritten — default OAuth path + clearly-labeled self-hosted advanced block; security notes updated |
| `docs/mcp-integrations.md` | Same structural change; DSN/token note kept and updated |
| `docs/getting-started.md` | Env-var guidance updated to reflect zero-config OAuth default |
| `docs/troubleshooting.md` | New Sentry-specific OAuth re-auth check + revoke link |
| `.env.example` | `SENTRY_TOKEN`/`ORG`/`PROJECT` removed; commented `SENTRY_ACCESS_TOKEN`/`SENTRY_HOST` block added for self-hosted opt-in |
| `scripts/verify.sh`, `.claude/hooks/session-start.sh` | Dropped `your_sentry_auth_token`/`your-org-slug` from placeholder greps (no longer in `.env.example`) |

## Honest limitations

- **Config shape is Claude-Code-specific.** `mcp/sentry-config.json`'s `{"type":"http","url":...}` shape is what Claude Code's `mcpServers` config expects. Other MCP clients (Cursor, Continue, VS Code) use slightly different shapes for remote HTTP MCP. Adopters using non-Claude-Code clients need to translate. This is documented in the README.
- **Self-hosted Sentry is unverified.** The `@sentry/mcp-server@0.32.0` instructions are based on the official `getsentry/sentry-mcp` README. I haven't end-to-end-tested against a self-hosted instance.

## Test plan

- [x] `jq empty mcp/sentry-config.json` → valid
- [x] `shellcheck` on hooks/workflows/scripts → exit 0
- [x] `actionlint` on workflows → exit 0
- [x] Placeholder greps in `verify.sh` + `session-start.sh` still match the remaining placeholders in `.env.example`
- [ ] CI run on this PR (visible after push)
- [ ] Manual: `claude mcp add --transport http sentry https://mcp.sentry.dev/mcp` then `/mcp` → OAuth round-trip succeeds (post-merge verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)