### PR TITLE
fix(hooks): force non-interactive pagers in post-tool-use (closes #9)

### DIFF
--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -7,6 +7,14 @@
 
 set -euo pipefail
 
+# Force non-interactive pagers — avoid subprocess hangs on minimal environments
+# (Git Bash without `less`, lean containers, CI runners). Every nested
+# git/npm/pytest invocation below inherits these. Use `${VAR:-default}` so
+# users who set their own pager are respected.
+export GIT_PAGER="${GIT_PAGER:-cat}"
+export PAGER="${PAGER:-cat}"
+export LESS="${LESS:-}"
+
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
Closes #9.

## Summary

Three exports added at the top of `.claude/hooks/post-tool-use.sh` so subprocesses it spawns (pytest, npm test, nested git invocations) cannot hang on a missing or interactive pager.

```bash
export GIT_PAGER="${GIT_PAGER:-cat}"
export PAGER="${PAGER:-cat}"
export LESS="${LESS:-}"
```

`${VAR:-default}` respects users who already set their own pager.

## Why

Originated from the post-merge analysis of OpenAI Codex's `windows-sandbox-rs/src/env.rs`, which forces non-interactive pagers on every spawned process. Without this, a hook-triggered `git log` or paginated npm warning hangs indefinitely on Git Bash without `less`, lean containers, and minimal CI runners.

## Acceptance criteria from #9

- [x] Three exports added near the top of `.claude/hooks/post-tool-use.sh`
- [x] Each uses `${VAR:-default}` so existing user values are respected
- [x] Inline comment explains the rationale
- [x] `bash scripts/test-hooks.sh` still passes (12/12 hook self-tests green)
- [x] `bash scripts/verify-ci.sh` still passes (shellcheck on the modified file)
- [x] No regression expected in the existing `Run Example Tests` CI job
- [x] Cross-platform smoke job remains green (validated locally; CI will confirm)

## Local validation

```
bash scripts/test-hooks.sh       → exit 0  (12/12)
bash scripts/verify-ci.sh        → exit 0  (10/10)
bash scripts/validate-skills.sh  → exit 0  (19/19)
bash scripts/verify.sh           → exit 0
```

## Diff

```
.claude/hooks/post-tool-use.sh | 8 ++++++++
1 file changed, 8 insertions(+)
```

## Scope control

This PR contains **only** the issue #9 change. It does not include #10 (docs on hooks vs sandbox boundary) or any other future-scope work.