### PR TITLE
docs(hooks): clarify hooks vs Claude Code sandbox boundary (closes #10)

### DIFF
--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -70,6 +70,10 @@ Each hook entry specifies a shell command to run. The hook can:
 
 **Customize:** Edit `BLOCKED_PATTERNS` and `WARN_PATTERNS` arrays in the script.
 
+> **Important:** This block-list is *defense in depth*, not the primary safety boundary.
+> See [Hooks vs Claude Code's Sandbox](#hooks-vs-claude-codes-sandbox) for what it can
+> and cannot catch.
+
 ---
 
 ### post-tool-use.sh
@@ -135,6 +139,55 @@ respects the contract Claude Code expects.
 > **What it does NOT verify:** whether Claude Code itself fires the hooks at the
 > right moment. That requires running inside Claude Code with appropriate tracing.
 > The self-test verifies the *scripts* are correct; firing is Claude Code's job.
+
+## Hooks vs Claude Code's Sandbox
+
+ClaudeMaxPower hooks are **defense in depth, not the primary safety boundary**. The
+primary boundary is Claude Code itself — its per-tool permission prompts, its
+permission mode, and any sandbox flags Claude Code exposes. Hooks are a thin
+backstop that catches a handful of obviously catastrophic patterns; they do not
+replace Claude Code's own enforcement.
+
+### What each layer enforces
+
+| Layer | Enforces | Examples |
+|-------|----------|----------|
+| **Claude Code (primary)** | Per-tool permission prompts; the active permission mode (`acceptEdits`, `auto`, `bypassPermissions`, `plan`); MCP server permissions; the harness's tool-call surface | Asks before running unfamiliar Bash commands; refuses unauthorized file writes in `plan` mode; mediates MCP tool access |
+| **ClaudeMaxPower hooks (backstop)** | A small regex block-list in `pre-tool-use.sh`; auto-test on edit in `post-tool-use.sh`; session-state persistence in `stop.sh` | Blocks `rm -rf /`, force-pushes to `main`, fork bombs; runs pytest after every `.py` edit |
+
+### What pre-tool-use.sh cannot catch
+
+The `BLOCKED_PATTERNS` array in `pre-tool-use.sh` is regex-matched against the
+literal command string passed to the `Bash` tool. By design, it cannot guarantee
+enforcement against:
+
+1. **Obfuscated commands.** Encoded payloads (`echo cm0gLXJmIC8K | base64 -d | sh`),
+   indirection through environment variables (`X="rm -rf /"; $X`), commands sourced
+   from disk (`sh ./hidden.sh`), or anything constructed at runtime can slip past
+   a regex match.
+2. **Dangerous behaviour via non-Bash tools.** The block-list runs only on the
+   `Bash` tool. An `Edit` that overwrites a load-bearing config, a `Write` that
+   deletes a file by replacing its contents with empty bytes, or a `WebFetch` that
+   exfiltrates secrets is not seen by the block-list at all.
+3. **Logic-level harm.** A correctly-formed `git push` to a wrong remote, a
+   syntactically valid SQL migration that drops the wrong column, or a benign
+   command run in a dangerous context — none of these match a syntactic pattern.
+
+### Practical guidance
+
+- **Respect Claude Code's permission prompts.** They are the primary boundary.
+  Approving a tool call is an authorization decision; do not rely on the hook
+  to second-guess it.
+- **Prefer `plan` mode for risky work.** Plan mode prevents non-readonly tools
+  from running until you exit plan mode explicitly. The hook block-list does
+  not have an equivalent.
+- **Treat the block-list as a backstop, not as authorization.** The fact that a
+  command was *not blocked* does not mean it is safe; it only means it did not
+  match a pattern.
+- **Extend the block-list as you learn.** If a real incident exposes a new class
+  of catastrophic command, add it to `BLOCKED_PATTERNS` so the next session is
+  protected — but always alongside the higher-layer fix (revoking a permission,
+  switching modes, fixing the workflow).
 
 ## Writing Your Own Hooks
 


### PR DESCRIPTION
Closes #10.

## Summary

Adds a new section to `docs/hooks-guide.md` titled **"Hooks vs Claude Code's Sandbox"** that frames ClaudeMaxPower hooks as defense in depth and names what each layer enforces. Also adds a one-line callout in the existing `pre-tool-use.sh` subsection that cross-links to the new section.

## What changed

`docs/hooks-guide.md` only — `+53` lines, no deletions.

The new section contains:

- A short prose paragraph stating that hooks are defense in depth and Claude Code itself is the primary boundary.
- A two-row comparison table distinguishing what each layer enforces.
- Three numbered categories the regex block-list cannot catch:
  1. Obfuscated commands (encoded payloads, env-var indirection, sourced scripts)
  2. Dangerous behaviour via non-Bash tools (Edit, Write, WebFetch)
  3. Logic-level harm (correct command, wrong context)
- A practical-guidance bullet list referencing Claude Code's permission modes (`acceptEdits`, `auto`, `bypassPermissions`, `plan`) by name.

Plus a small callout block inside the existing `pre-tool-use.sh` subsection so a reader landing on the block-list sees the boundary statement immediately.

## Acceptance criteria from #10

- [x] New section added to `docs/hooks-guide.md` (title: "Hooks vs Claude Code's Sandbox")
- [x] States the defense-in-depth framing explicitly
- [x] Lists the three categories the regex block-list cannot catch
- [x] References Claude Code's permission modes (`acceptEdits` / `auto` / `bypassPermissions` / `plan`) by name
- [x] Cross-links from the existing `pre-tool-use.sh` subsection
- [x] No code changes — documentation-only (1 file, +53/-0)

## Local validation

```
bash scripts/verify-ci.sh  → exit 0
```

`markdownlint` is not installed locally; the CI `lint-markdown` job (which currently uses `--disable MD013 MD033 MD041`) will validate on PR.

## Scope control

This PR contains **only** the issue #10 change. No hook or script behaviour was modified. No future-scope material (Codex `windows-sandbox-rs` notes, additional Windows hardening) is included.