### PR TITLE
feat(setup): warn on unfilled .env placeholders after setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -104,6 +104,56 @@ else
   ok ".env already exists."
 fi
 
+# 2b. Detect unfilled .env placeholders.
+# A common first-run footgun: setup says "complete!", the user opens Claude Code,
+# runs /fix-issue or /review-pr, and gets a cryptic auth failure because the .env
+# values are still the placeholder defaults from .env.example. We surface that
+# state as a warning at setup time so the failure is loud and close to the cause.
+# We never print the actual value — only the variable name and what it affects.
+check_env_placeholder() {
+  # Args: VAR_NAME, placeholder_default, impact_description
+  local var="$1"
+  local placeholder="$2"
+  local impact="$3"
+  local current
+
+  # Read the first matching assignment, strip surrounding quotes and any trailing CR.
+  # `|| true` neutralises pipefail when grep finds no match — that case is
+  # handled by the empty-string check below.
+  current="$(grep -E "^[[:space:]]*${var}=" .env 2>/dev/null \
+              | head -1 \
+              | sed -E "s/^[[:space:]]*${var}=//" \
+              | tr -d '\r' || true)"
+  current="${current#\"}"; current="${current%\"}"
+  current="${current#\'}"; current="${current%\'}"
+
+  # Treat missing key, empty value, and exact placeholder as unfilled.
+  if [ -z "$current" ] || [ "$current" = "$placeholder" ]; then
+    warn "$var is unfilled. Affects: $impact"
+    return 1
+  fi
+  return 0
+}
+
+UNFILLED=0
+if [ -f ".env" ]; then
+  echo ""
+  echo "Checking .env for unfilled placeholders..."
+  check_env_placeholder "GITHUB_TOKEN" "ghp_your_token_here" \
+    "/fix-issue, /review-pr, MCP GitHub integration (auth will fail)" || UNFILLED=$((UNFILLED + 1))
+  check_env_placeholder "DEFAULT_REPO" "your-username/your-repo" \
+    "skills that default to a repo when --repo is omitted" || UNFILLED=$((UNFILLED + 1))
+  check_env_placeholder "DB_URL" "postgresql://user:password@localhost:5432/mydb" \
+    "examples and workflows that read DB_URL" || UNFILLED=$((UNFILLED + 1))
+
+  if [ "$UNFILLED" -eq 0 ]; then
+    ok ".env values look filled (no known placeholders detected)."
+  else
+    warn "$UNFILLED .env value(s) still hold placeholder defaults. Edit .env to enable affected workflows."
+    warn "Setup will continue — placeholders are warnings, not hard failures."
+  fi
+fi
+
 # 3. Make hook scripts executable
 echo ""
 echo "Making hook scripts executable..."


### PR DESCRIPTION
## Summary

Closes a first-time-user friction identified during the post-#8/#11/#12 review:
`scripts/setup.sh` happily printed `Setup complete!` even when `.env` still held the
placeholder defaults from `.env.example`. The user's first skill invocation (`/fix-issue`,
`/review-pr`, `/assemble-team`) then failed with a cryptic auth error far from the cause.

This PR adds a `check_env_placeholder` helper that runs after `.env` is created or detected.
For each known placeholder it surfaces a labeled warning naming the variable and the
workflows it blocks. Actual values are never printed.

## What changed

- `scripts/setup.sh` — new step 2b: detect known placeholders for `GITHUB_TOKEN`,
  `DEFAULT_REPO`, `DB_URL`. Per unfilled var, emit one `[WARN]` line. Setup continues —
  placeholders are warnings, not hard failures.

## Scope control

This PR intentionally does **not**:

- Expand the 3-OS CI matrix (PR #8 follow-up #3 — deferred).
- Add a test harness for `scripts/auto-dream.sh` (PR #8 follow-up #4 — to be filed as
  a separate issue).
- Change `scripts/verify-ci.sh` semantics (separate issue to be filed for honesty about
  what it skips vs CI).

Each of those is tracked or about to be tracked as its own issue.

## Validation evidence

Run on Windows 11 / Git Bash:

| Check | Result |
|---|---|
| `rm .env && bash scripts/setup.sh` | three `[WARN]` lines (GITHUB_TOKEN, DEFAULT_REPO, DB_URL), then setup completes |
| Filled `.env` and rerun `bash scripts/setup.sh` | single `[OK] .env values look filled` line |
| `bash scripts/verify-ci.sh` | exit 0, "All 10 checks passed — local matches CI" |
| `bash scripts/test-hooks.sh` | exit 0, "All 12 hook self-tests passed" |
| `bash scripts/validate-skills.sh` | exit 0 |
| `bash scripts/validate-skills.sh --strict` | exit 0 |
| `bash scripts/verify.sh` | exit 0 (todo-app seeded-bug failures remain INFO by default) |
| Re-run `setup.sh` twice consecutively | `git status` clean, no file mutations beyond `scripts/setup.sh` itself |

Pager-shim and CRLF-fix changes from PRs #11 and #8 remain intact — no edits to
`post-tool-use.sh` or `scripts/generate-commands.py`.

## Why this approach

- **Warn, don't fail.** A user might run `setup.sh` to scaffold the repo and intentionally
  leave tokens blank if they only need offline pieces. Hard-failing would be hostile.
- **Don't print values.** Even when a value is non-placeholder, the helper only ever logs
  the variable name — keeps secrets out of CI logs and screen shares.
- **Idempotent.** A configured `.env` produces one clean `[OK]` line. Re-running setup
  twice in a row leaves `git status` empty.
- **No verify-ci.sh dependency.** The plan-review noted that `verify-ci.sh` currently
  claims to mirror CI while skipping markdown lint and example tests. Wiring it in here
  would create a false sense of safety; that's tracked separately.

## Risk notes

The check uses a small static list of placeholders mirroring `.env.example`. If
`.env.example` gains a new variable, the check will silently skip it until the helper
is updated. That is acceptable for a warning system; future work can pull the list
from `.env.example` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)