### PR TITLE
Resolve 8 CodeQL workflow-permissions alerts; bash 3.2 compat; real SECURITY.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   validate-shell:
     name: Validate Shell Scripts

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,98 @@
+# Security Policy
+
+## Supported Versions
+
+ClaudeMaxPower is a template repository — users typically clone or fork the
+latest `main`. Security fixes land on `main` and on the most recent tagged
+release. Older releases do not receive backports.
+
+| Version          | Supported          |
+| ---------------- | ------------------ |
+| `main` (rolling) | :white_check_mark: |
+| Latest tag       | :white_check_mark: |
+| Older tags       | :x:                |
+
+If you have a fork or a clone pinned to an older snapshot, rebase onto `main`
+to pick up security fixes.
+
+## Reporting a Vulnerability
+
+Please report security issues **privately**, not as a public issue or PR.
+
+**Preferred:** open a [private security advisory][advisory] on this repository.
+GitHub keeps the discussion private until a fix is published and lets us
+coordinate disclosure with you.
+
+[advisory]: https://github.com/michelbr84/ClaudeMaxPower/security/advisories/new
+
+**Alternate:** if private advisories are unavailable to you, contact the
+maintainer through the contact channels on the
+[project owner's profile](https://github.com/michelbr84).
+
+When reporting, please include:
+
+- A clear description of the issue and its impact.
+- Reproduction steps or a minimal proof-of-concept.
+- The commit SHA or release tag where you observed it.
+- Any suggested mitigation, if you have one.
+
+### What to expect
+
+- **Acknowledgement** within 72 hours of receipt.
+- **Initial assessment** (severity, scope, reproducibility) within 7 days.
+- **Status updates** at least every 14 days while the issue is open.
+- **Coordinated disclosure**: once a fix lands on `main`, the advisory is
+  published with credit to the reporter — unless you ask to remain anonymous.
+
+## In Scope
+
+Examples of issues that ClaudeMaxPower considers in scope:
+
+- A hook script (`session-start.sh`, `pre-tool-use.sh`, `post-tool-use.sh`,
+  `stop.sh`) that can be tricked into executing an unintended command or
+  exfiltrating data.
+- A workflow under `.github/workflows/` that leaks tokens or grants more
+  permission than necessary.
+- A skill or agent that mishandles `.env`, secrets, or credentials.
+- A path-traversal or arbitrary-file-write in any script under `scripts/`,
+  `workflows/`, or `.claude/`.
+- A bypass of the `BLOCKED_PATTERNS` allow/deny list in `pre-tool-use.sh`
+  that would let a clearly-malicious command through.
+- Supply-chain risks introduced by `scripts/setup.sh`, the bootstrap prompt,
+  or any auto-installed tool.
+
+## Out of Scope
+
+The following are explicitly out of scope for this repository:
+
+- Vulnerabilities in [Claude Code][cc], the [Claude Agent SDK][sdk], or the
+  Anthropic API itself. Report those upstream to Anthropic.
+- Vulnerabilities in third-party MCP servers configured via `mcp/*.json`.
+  Report those to the respective MCP server projects.
+- Risks inherent to running an AI coding assistant against your own code
+  — the assistant can read or modify any file you authorize it to touch.
+  Use Claude Code's permission modes and the hook block-list as defense in
+  depth (see `docs/hooks-guide.md`).
+- Issues in user-customized hooks, skills, or agents that ClaudeMaxPower
+  does not ship by default.
+- Findings from automated scanners that have no demonstrable security
+  impact (style warnings, informational notices, theoretical risks without
+  a concrete attack path).
+
+[cc]: https://www.anthropic.com/claude-code
+[sdk]: https://docs.anthropic.com/en/api/agent-sdk
+
+## Defensive Guidance for Users of This Template
+
+If you have installed ClaudeMaxPower into your own project:
+
+- Never commit `.env`, real API tokens, or production credentials. The
+  pre-tool-use hook and CI's `Check for Secrets` job are backstops, not
+  primary controls.
+- Review every PR before merging — Claude-authored commits are not exempt.
+- Keep the hooks enabled and treat `pre-tool-use.sh`'s block-list as
+  defense in depth, not the primary safety boundary
+  (see `docs/hooks-guide.md`).
+- Run `bash scripts/test-hooks.sh` and `bash scripts/test-auto-dream.sh`
+  after customizing hooks or `auto-dream.sh`.
+- Prefer Claude Code's `plan` mode for risky or destructive work.

--- a/docs/auto-dream-guide.md
+++ b/docs/auto-dream-guide.md
@@ -117,14 +117,11 @@ The same test runs in CI alongside `scripts/test-hooks.sh` (see the
 on Ubuntu, macOS, and Windows. If you change `scripts/auto-dream.sh`, re-run the
 self-test before sending a PR.
 
-> **Bash 4+ note.** Auto Dream's Phase 4 (rebuild index) uses associative arrays
-> (`declare -A`), introduced in bash 4. macOS ships `/bin/bash` 3.2, so the
-> consolidation path crashes there. The self-test detects bash version at runtime
-> and skips the consolidation-dependent cases under bash 3.x with a `[SKIP]`
-> message — the remaining cases (missing memory dir, under-threshold, live lock)
-> still run on every platform. macOS users who want full Auto Dream coverage
-> should install bash via Homebrew (`brew install bash`) and ensure it is on
-> PATH before invoking auto-dream.sh.
+> **Portability note.** Auto Dream runs on bash 3.2+, including macOS's stock
+> `/bin/bash`. Phase 4 (rebuild index) avoids `declare -A` by bucketing entries
+> into a temporary per-type directory; the `${var^}` capitalization expansion
+> is also avoided. The self-test exercises the consolidation path on every
+> platform without skips.
 
 ## What Auto Dream Does NOT Do
 

--- a/scripts/auto-dream.sh
+++ b/scripts/auto-dream.sh
@@ -30,8 +30,12 @@ log_warn()  { echo -e "${YELLOW}[AutoDream]${NC} $1"; }
 log_error() { echo -e "${RED}[AutoDream]${NC} $1"; }
 
 # shellcheck disable=SC2317  # invoked indirectly via `trap cleanup EXIT` below
+type_dir=""
 cleanup() {
     rm -f "$LOCK_FILE" 2>/dev/null || true
+    if [ -n "${type_dir:-}" ] && [ -d "$type_dir" ]; then
+        rm -rf "$type_dir" 2>/dev/null || true
+    fi
 }
 
 # --- Validation ---
@@ -165,10 +169,13 @@ log_info "Found ${duplicate_count} potential duplicates."
 # --- Phase 4: Rebuild index ---
 log_info "Phase 4: Rebuilding MEMORY.md index..."
 
-# Group files by type
-declare -A type_files
+# Group files by type. Bash 3.2 lacks `declare -A`, so we bucket entries into
+# one file per type inside an ephemeral temp dir; cleanup() removes it on exit.
+type_dir="$(mktemp -d "${TMPDIR:-/tmp}/auto-dream-types.XXXXXX")"
+
 for file in "${memory_files[@]}"; do
     type=$(grep -m1 '^type:' "$file" 2>/dev/null | sed 's/^type: *//' || echo "uncategorized")
+    [ -z "$type" ] && type="uncategorized"
     filename=$(basename "$file")
     name=$(grep -m1 '^name:' "$file" 2>/dev/null | sed 's/^name: *//' || echo "$filename")
     description=$(grep -m1 '^description:' "$file" 2>/dev/null | sed 's/^description: *//' || echo "")
@@ -178,22 +185,50 @@ for file in "${memory_files[@]}"; do
         description="${description:0:77}..."
     fi
 
-    entry="- [${name}](${filename}) -- ${description}"
-    type_files["$type"]="${type_files[$type]:-}${entry}\n"
+    # Restrict the type to characters safe for a filename to avoid surprises.
+    safe_type=$(printf '%s' "$type" | tr -c 'a-zA-Z0-9_-' '_')
+    [ -z "$safe_type" ] && safe_type="uncategorized"
+
+    printf -- '- [%s](%s) -- %s\n' "$name" "$filename" "$description" \
+        >> "$type_dir/${safe_type}.txt"
 done
 
-# Write new index
+# Capitalize first letter without bash 4's `${var^}` (not in macOS /bin/bash 3.2).
+capitalize() {
+    local s="$1"
+    [ -z "$s" ] && { printf ''; return; }
+    local first rest
+    first=$(printf '%s' "${s:0:1}" | tr '[:lower:]' '[:upper:]')
+    rest="${s:1}"
+    printf '%s%s' "$first" "$rest"
+}
+
+# Write new index — known types first in canonical order, then any extras.
 {
     echo "# Memory Index"
     echo ""
 
+    written=" "
     for type in "user" "feedback" "project" "reference" "uncategorized"; do
-        if [ -n "${type_files[$type]:-}" ]; then
-            # Capitalize first letter
-            header="${type^}"
-            echo "## ${header}"
-            echo -e "${type_files[$type]}"
+        f="$type_dir/${type}.txt"
+        if [ -s "$f" ]; then
+            echo "## $(capitalize "$type")"
+            cat "$f"
+            echo ""
+            written="$written$type "
         fi
+    done
+
+    # Catch any unknown types not in the canonical list.
+    for f in "$type_dir"/*.txt; do
+        [ -f "$f" ] || continue
+        type_base=$(basename "$f" .txt)
+        case "$written" in
+            *" $type_base "*) continue ;;
+        esac
+        echo "## $(capitalize "$type_base")"
+        cat "$f"
+        echo ""
     done
 } > "$MEMORY_INDEX"
 

--- a/scripts/auto-dream.sh
+++ b/scripts/auto-dream.sh
@@ -29,8 +29,9 @@ log_ok()    { echo -e "${GREEN}[AutoDream]${NC} $1"; }
 log_warn()  { echo -e "${YELLOW}[AutoDream]${NC} $1"; }
 log_error() { echo -e "${RED}[AutoDream]${NC} $1"; }
 
-# shellcheck disable=SC2317  # invoked indirectly via `trap cleanup EXIT` below
 type_dir=""
+
+# shellcheck disable=SC2317  # invoked indirectly via `trap cleanup EXIT` below
 cleanup() {
     rm -f "$LOCK_FILE" 2>/dev/null || true
     if [ -n "${type_dir:-}" ] && [ -d "$type_dir" ]; then

--- a/scripts/test-auto-dream.sh
+++ b/scripts/test-auto-dream.sh
@@ -18,13 +18,9 @@
 #                                        unchanged (skipped cleanly)
 #
 # Bash version note:
-#   auto-dream.sh's Phase 4 (rebuild index) uses `declare -A` — a bash 4+
-#   feature. macOS ships /bin/bash 3.2, so the consolidation path crashes
-#   on stock macOS shells. Tests that exercise consolidation (cases 3 and
-#   4 above) are SKIPPED when running under bash < 4 rather than reported
-#   as failures. The script still validates the remaining cases on every
-#   platform. Making auto-dream.sh bash-3.2-compatible is tracked as a
-#   separate item.
+#   auto-dream.sh is bash 3.2 compatible (Phase 4 was reworked off
+#   `declare -A` to use a per-type temp dir). All cases below run on every
+#   platform, including macOS /bin/bash 3.2. No SKIPs on bash version.
 #
 # What is NOT tested:
 #   - Whether session-start hook actually triggers auto-dream.sh in production
@@ -151,15 +147,6 @@ echo "Workspace: $CMP_TMPDIR"
 echo "Bash:      ${BASH_VERSION:-unknown}"
 echo ""
 
-# auto-dream.sh's Phase 4 uses `declare -A` (bash 4+). macOS system bash is
-# 3.2, so consolidation crashes there. Skip consolidation-dependent cases
-# under bash < 4 with a clear message rather than failing on a known SUT
-# limitation that is intentionally out of scope for this PR.
-HAS_ASSOC_ARRAY=true
-if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
-  HAS_ASSOC_ARRAY=false
-fi
-
 NOW=$(date +%s)
 STALE_EPOCH=$((NOW - 25 * 3600))   # 25 hours ago — over the 24h threshold
 RECENT_EPOCH="$NOW"                # right now — under threshold
@@ -204,80 +191,72 @@ fi
 
 # 3. Over-threshold → consolidation runs ───────────────────────────────────
 note "over-threshold (>24h, 5+ sessions) → consolidation runs, MEMORY.md rebuilt"
-if [ "$HAS_ASSOC_ARRAY" = "true" ]; then
-  mem=$(make_memory_dir over-threshold)
-  write_state "$mem" "$STALE_EPOCH" 10
-  write_sample_memory "$mem" "user_profile" "user"
-  write_sample_memory "$mem" "feedback_one"  "feedback"
+mem=$(make_memory_dir over-threshold)
+write_state "$mem" "$STALE_EPOCH" 10
+write_sample_memory "$mem" "user_profile" "user"
+write_sample_memory "$mem" "feedback_one"  "feedback"
 
-  rc=$(run_auto_dream "$mem")
-  assert_eq "exits 0 in over-threshold case" "0" "$rc"
+rc=$(run_auto_dream "$mem")
+assert_eq "exits 0 in over-threshold case" "0" "$rc"
 
-  after_epoch=$(read_state_int "$mem/.dream-state.json" "last_dream_epoch")
-  if [ -n "$after_epoch" ] && [ "$after_epoch" -gt "$STALE_EPOCH" ]; then
-    echo -e "  ${GREEN}[PASS]${NC} last_dream_epoch advanced past stale value"
-    pass=$((pass + 1))
-  else
-    echo -e "  ${RED}[FAIL]${NC} last_dream_epoch did not advance (stale=$STALE_EPOCH, now=$after_epoch)"
-    fail=$((fail + 1))
-  fi
-
-  after_sessions=$(read_state_int "$mem/.dream-state.json" "sessions_since")
-  assert_eq "sessions_since reset to 0 after consolidation" "0" "$after_sessions"
-
-  files_processed=$(read_state_int "$mem/.dream-state.json" "files_processed")
-  assert_eq "files_processed records 2 input files" "2" "$files_processed"
-
-  if [ -f "$mem/MEMORY.md" ] && grep -q "^# Memory Index" "$mem/MEMORY.md"; then
-    echo -e "  ${GREEN}[PASS]${NC} MEMORY.md rebuilt with header"
-    pass=$((pass + 1))
-  else
-    echo -e "  ${RED}[FAIL]${NC} MEMORY.md missing or malformed"
-    fail=$((fail + 1))
-  fi
-
-  if grep -q "## User" "$mem/MEMORY.md" 2>/dev/null \
-     && grep -q "## Feedback" "$mem/MEMORY.md" 2>/dev/null; then
-    echo -e "  ${GREEN}[PASS]${NC} MEMORY.md groups entries by type"
-    pass=$((pass + 1))
-  else
-    echo -e "  ${RED}[FAIL]${NC} MEMORY.md type sections missing"
-    fail=$((fail + 1))
-  fi
+after_epoch=$(read_state_int "$mem/.dream-state.json" "last_dream_epoch")
+if [ -n "$after_epoch" ] && [ "$after_epoch" -gt "$STALE_EPOCH" ]; then
+  echo -e "  ${GREEN}[PASS]${NC} last_dream_epoch advanced past stale value"
+  pass=$((pass + 1))
 else
-  echo -e "  ${YELLOW}[SKIP]${NC} bash ${BASH_VERSINFO[0]:-?} < 4 — auto-dream.sh Phase 4 needs assoc arrays"
+  echo -e "  ${RED}[FAIL]${NC} last_dream_epoch did not advance (stale=$STALE_EPOCH, now=$after_epoch)"
+  fail=$((fail + 1))
+fi
+
+after_sessions=$(read_state_int "$mem/.dream-state.json" "sessions_since")
+assert_eq "sessions_since reset to 0 after consolidation" "0" "$after_sessions"
+
+files_processed=$(read_state_int "$mem/.dream-state.json" "files_processed")
+assert_eq "files_processed records 2 input files" "2" "$files_processed"
+
+if [ -f "$mem/MEMORY.md" ] && grep -q "^# Memory Index" "$mem/MEMORY.md"; then
+  echo -e "  ${GREEN}[PASS]${NC} MEMORY.md rebuilt with header"
+  pass=$((pass + 1))
+else
+  echo -e "  ${RED}[FAIL]${NC} MEMORY.md missing or malformed"
+  fail=$((fail + 1))
+fi
+
+if grep -q "## User" "$mem/MEMORY.md" 2>/dev/null \
+   && grep -q "## Feedback" "$mem/MEMORY.md" 2>/dev/null; then
+  echo -e "  ${GREEN}[PASS]${NC} MEMORY.md groups entries by type"
+  pass=$((pass + 1))
+else
+  echo -e "  ${RED}[FAIL]${NC} MEMORY.md type sections missing"
+  fail=$((fail + 1))
 fi
 
 # 4. Stale lock (dead PID) → cleared, dream runs ───────────────────────────
 note "stale lock (dead PID) → cleared, consolidation runs"
-if [ "$HAS_ASSOC_ARRAY" = "true" ]; then
-  mem=$(make_memory_dir stale-lock)
-  write_state "$mem" "$STALE_EPOCH" 10
-  write_sample_memory "$mem" "user_profile" "user"
+mem=$(make_memory_dir stale-lock)
+write_state "$mem" "$STALE_EPOCH" 10
+write_sample_memory "$mem" "user_profile" "user"
 
-  dead_pid=$(make_dead_pid)
-  echo "$dead_pid" > "$mem/.dream.lock"
+dead_pid=$(make_dead_pid)
+echo "$dead_pid" > "$mem/.dream.lock"
 
-  rc=$(run_auto_dream "$mem")
-  assert_eq "exits 0 with stale lock present" "0" "$rc"
+rc=$(run_auto_dream "$mem")
+assert_eq "exits 0 with stale lock present" "0" "$rc"
 
-  if [ ! -f "$mem/.dream.lock" ]; then
-    echo -e "  ${GREEN}[PASS]${NC} stale lock removed (cleanup trap fired)"
-    pass=$((pass + 1))
-  else
-    echo -e "  ${RED}[FAIL]${NC} stale lock NOT removed"
-    fail=$((fail + 1))
-  fi
-
-  if [ -f "$mem/MEMORY.md" ]; then
-    echo -e "  ${GREEN}[PASS]${NC} consolidation ran past the stale lock"
-    pass=$((pass + 1))
-  else
-    echo -e "  ${RED}[FAIL]${NC} consolidation did not run"
-    fail=$((fail + 1))
-  fi
+if [ ! -f "$mem/.dream.lock" ]; then
+  echo -e "  ${GREEN}[PASS]${NC} stale lock removed (cleanup trap fired)"
+  pass=$((pass + 1))
 else
-  echo -e "  ${YELLOW}[SKIP]${NC} bash ${BASH_VERSINFO[0]:-?} < 4 — same SUT limitation as case 3"
+  echo -e "  ${RED}[FAIL]${NC} stale lock NOT removed"
+  fail=$((fail + 1))
+fi
+
+if [ -f "$mem/MEMORY.md" ]; then
+  echo -e "  ${GREEN}[PASS]${NC} consolidation ran past the stale lock"
+  pass=$((pass + 1))
+else
+  echo -e "  ${RED}[FAIL]${NC} consolidation did not run"
+  fail=$((fail + 1))
 fi
 
 # 5. Live lock (running PID) → skipped, state unchanged ────────────────────


### PR DESCRIPTION
## Summary

- **Closes 8 CodeQL "Workflow does not contain permissions" alerts** by adding a top-level `permissions: contents: read` block to `.github/workflows/ci.yml`. One declaration covers all eight jobs the scanner flagged (lines 11, 34, 48, 62, 87, 108, 133, 156). `release.yml` already had per-job permissions and is unchanged.
- **Closes #18 (auto-dream macOS bash 3.2 compat).** `scripts/auto-dream.sh` Phase 4 no longer uses `declare -A` (bash 4+) or `${var^}` capitalization. Entries bucket into a per-type temp directory; capitalization uses `tr`. The temp dir is cleaned up on exit alongside the lock file. `scripts/test-auto-dream.sh` drops its `HAS_ASSOC_ARRAY` skip — cases 3 (over-threshold) and 4 (stale lock) now run on every platform, including macOS `/bin/bash` 3.2.
- **Replaces the placeholder `SECURITY.md`** (GitHub's default template — fictional 5.1.x / 4.0.x version table, "tell people how to report a vulnerability" boilerplate) with a real policy: rolling-`main` support model, private security advisory as the preferred reporting channel, explicit in-scope/out-of-scope sections aimed at this template's actual surface (hook scripts, workflows, MCP boundaries), and defensive guidance for downstream users. Supersedes the placeholder in PRs #20 and #21.
- **Doc:** `docs/auto-dream-guide.md` swaps the "Bash 4+ note" for a portability note matching the new 3.2+ baseline.
- **Lint:** `# shellcheck disable=SC2317` rebound to the `cleanup()` function definition (an intervening `type_dir=""` assignment had captured the directive in the previous commit).

## Test plan

- [x] `bash scripts/test-auto-dream.sh` — all 19 cases pass on bash 5.2 locally
- [x] `bash scripts/test-hooks.sh` — all 12 hook self-tests pass
- [x] `bash scripts/validate-skills.sh` — clean
- [x] `shellcheck v0.10.0` on `scripts/*.sh`, `.claude/hooks/*.sh`, `workflows/*.sh` — clean
- [x] `bash -n` syntax check on both modified scripts — clean
- [ ] CI cross-platform smoke turns green on `ubuntu-latest`, `macos-latest`, `windows-latest` (the macOS run is the meaningful new coverage — it previously had to skip Phase 4)
- [ ] CodeQL re-scan after merge confirms the 8 workflow-permissions alerts close

## Notes for the reviewer

- PR #20 ("Create SECURITY.md") and PR #21 ("Fix formatting issue in SECURITY.md") become redundant once this lands — the SECURITY.md they propose still carries GitHub's default placeholders. Recommend closing both with a comment pointing here.
- PR #19 (`.github/dependabot.yml`) is independent and also placeholder content (`package-ecosystem: ""`); it's not addressed here. Decide separately whether to populate it (`github-actions` + `pip` for `examples/todo-app/requirements.txt`) or close it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VB7Umj2AUiwwJc6gxrrSQw)_