### PR TITLE
docs(health): add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners for ClaudeMaxPower
+#
+# This file declares default reviewers per path. GitHub will request review
+# from listed owners automatically when a PR touches matching files.
+#
+# Syntax: <pattern> <owner1> [owner2] ...
+# Owners must be GitHub logins or teams that have at least read access to the
+# repository. Order matters — later patterns override earlier ones.
+#
+# See: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Maintainers note: this file lists only humans who have actually committed
+# to the relevant paths. Bot accounts (dependabot[bot]) and AI co-author
+# trailers are intentionally excluded.
+
+# Default owner for everything not matched below.
+* @michelbr84


### PR DESCRIPTION
## Summary

Adds a `CODEOWNERS` file at the repository root with `@michelbr84` as the
default owner for all paths.

## Related issues / specs / plans

- Addresses the LOW-severity "Missing CODEOWNERS" finding from
  `.github-health-reports/full_05_07_26.md` (audit score 83/100)
- Continues the ratchet: PR #29 (.gitignore), PR #30 (CONTRIBUTING.md),
  PR #31 (PR template), this PR (CODEOWNERS)

## Type of change

- [x] docs (documentation only)

## Test plan

- [x] `git diff --stat` shows a single new 17-line file at the repo root
- [x] Owner population follows the skill rule: only humans who have
      actually committed to the relevant paths (`michelbr84`); bot accounts
      and AI co-author trailers are intentionally excluded
- [x] `Verify Project Structure` CI does not require CODEOWNERS, so this
      is purely additive — no CI behavior change, no required-checks change

## Iron-law checklist

- [x] No production code change.
- [x] No CI is being silenced.
- [x] No branch protection or security setting is changed.

## Predicted score impact

Documentation subscore: 9/10 -> 10/10.
Estimated overall: 86 -> 87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)