### PR TITLE
chore(dev): document optional local Postgres setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,13 @@ GITHUB_TOKEN=ghp_your_token_here
 # SENTRY_ACCESS_TOKEN=
 # SENTRY_HOST=
 
-# Database (optional — for DB-to-UI workflow examples)
-DB_URL=postgresql://user:password@localhost:5432/mydb
+# Optional local-dev Postgres (see docs/dev-postgres.md).
+# ClaudeMaxPower itself does NOT require Postgres — this is for example apps and
+# experiments. Values below are PLACEHOLDERS. Replace POSTGRES_PASSWORD with a strong
+# local-only secret in your .env. Never commit .env. Never paste real DB credentials
+# into issues, PRs, commits, docs, screenshots, or chat.
+POSTGRES_PASSWORD=change-me-local-only
+DB_URL=postgresql://postgres:change-me-local-only@127.0.0.1:5432/claudemaxpower
 
 # Default GitHub repository for skills (owner/repo format)
 DEFAULT_REPO=your-username/your-repo

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,44 @@
+# docker-compose.postgres.yml — OPTIONAL local-development Postgres for ClaudeMaxPower.
+#
+# ClaudeMaxPower itself does NOT require Postgres. This file exists only as a
+# convenience for example apps and local experiments that need a real DB.
+# See docs/dev-postgres.md for setup, security notes, and rotation steps.
+#
+# Always invoke explicitly with `-f docker-compose.postgres.yml` so the
+# optional nature is visible in every command.
+#
+#   start  : docker compose -f docker-compose.postgres.yml up -d
+#   stop   : docker compose -f docker-compose.postgres.yml down
+#   reset  : docker compose -f docker-compose.postgres.yml down -v
+#   shell  : docker compose -f docker-compose.postgres.yml exec postgres \
+#            psql -U postgres -d claudemaxpower
+#
+# Security:
+#   - Port is bound to 127.0.0.1 only (loopback). Never change to 0.0.0.0
+#     or a bare "5432:5432" — that would expose Postgres to the LAN.
+#   - POSTGRES_PASSWORD has no default. The compose file refuses to start
+#     unless the variable is set in your local .env (which is gitignored).
+#   - .env is in .gitignore. Never commit it. Never paste real DB
+#     credentials into issues, PRs, commits, docs, screenshots, or chat.
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: claudemaxpower-postgres
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      POSTGRES_DB: claudemaxpower
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env (see .env.example and docs/dev-postgres.md)}
+    volumes:
+      - claudemaxpower_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d claudemaxpower"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  claudemaxpower_pgdata:

--- a/docs/dev-postgres.md
+++ b/docs/dev-postgres.md
@@ -1,0 +1,145 @@
+# Optional Local Postgres for Development
+
+> **Is this required?** No. ClaudeMaxPower does **not** require Postgres. This guide
+> documents an *optional* local-development helper for example apps and experiments
+> that need a real database. Skip this entire page unless you specifically need a
+> local Postgres.
+
+## What this provides
+
+- Postgres 16 in a Docker container, scoped to your machine only.
+- A named volume so data survives `down`/`up`.
+- A safety-first defaults profile: loopback-only port, no hardcoded password.
+- Documentation for setup, common operations, and password rotation.
+
+## Prerequisites
+
+- Docker Desktop or Docker Engine + the Docker Compose plugin (`docker compose`, not
+  the legacy `docker-compose`).
+
+Verify with:
+
+```bash
+docker --version
+docker compose version
+```
+
+## Setup
+
+1. **Copy the env template if you have not already:**
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. **Set a strong local-only password.** Edit `.env` and replace the placeholder
+   `POSTGRES_PASSWORD=change-me-local-only` with a value of your choosing.
+
+   - Use a generator (`openssl rand -hex 24` is fine).
+   - This password is for your laptop only. It is never committed because `.env` is
+     gitignored.
+   - Update `DB_URL` in the same `.env` so the password matches.
+
+3. **Start Postgres:**
+
+   ```bash
+   docker compose -f docker-compose.postgres.yml up -d
+   ```
+
+   The first run pulls the `postgres:16` image, creates the `claudemaxpower_pgdata`
+   named volume, and exposes the database on `127.0.0.1:5432`.
+
+4. **Confirm it is up:**
+
+   ```bash
+   docker compose -f docker-compose.postgres.yml ps
+   docker compose -f docker-compose.postgres.yml exec postgres pg_isready -U postgres
+   ```
+
+## Common commands
+
+| Action | Command |
+|---|---|
+| Start (background) | `docker compose -f docker-compose.postgres.yml up -d` |
+| Stop (keep data) | `docker compose -f docker-compose.postgres.yml down` |
+| Stop and **delete** data | `docker compose -f docker-compose.postgres.yml down -v` |
+| Tail logs | `docker compose -f docker-compose.postgres.yml logs -f postgres` |
+| Open psql shell | `docker compose -f docker-compose.postgres.yml exec postgres psql -U postgres -d claudemaxpower` |
+| Status | `docker compose -f docker-compose.postgres.yml ps` |
+
+## Connecting from an app
+
+The example connection string follows the standard libpq format:
+
+```
+postgresql://postgres:<your-local-password>@127.0.0.1:5432/claudemaxpower
+```
+
+A psql one-liner from the host (requires `psql` installed locally):
+
+```bash
+psql "postgresql://postgres:$POSTGRES_PASSWORD@127.0.0.1:5432/claudemaxpower"
+```
+
+## Rotating the password
+
+Do this immediately if your local password ever appeared in a screenshot, chat
+transcript, issue, PR, commit, log file, or terminal recording — even if it never
+reached the public repo.
+
+1. Stop the container (data preserved):
+
+   ```bash
+   docker compose -f docker-compose.postgres.yml down
+   ```
+
+2. Wipe the volume so the new password takes effect from a fresh data directory:
+
+   ```bash
+   docker compose -f docker-compose.postgres.yml down -v
+   ```
+
+   (Postgres only sets the password from `POSTGRES_PASSWORD` when initialising a new
+   data directory. Without `-v`, the old password persists.)
+
+3. Update the password in `.env`. Update `DB_URL` to match.
+
+4. Start again:
+
+   ```bash
+   docker compose -f docker-compose.postgres.yml up -d
+   ```
+
+5. Audit any place the old value might have leaked: shell history (`history | grep
+   postgresql`), terminal scrollback, screenshots, chat tools, agent memory stores.
+   Where you cannot delete the trace, treat the value as compromised forever and
+   never reuse it.
+
+## Security rules
+
+- **Loopback only.** The compose file binds `127.0.0.1:5432:5432`. Never change this
+  to `5432:5432` or `0.0.0.0:5432:5432` — that would expose Postgres to your LAN
+  (and on some hosts, the open Internet).
+- **No default password.** `POSTGRES_PASSWORD` is read from `.env` with the
+  `${POSTGRES_PASSWORD:?...}` syntax, so the container refuses to start if the
+  variable is missing. There is no hardcoded fallback to leak.
+- **Never commit `.env`.** It is in `.gitignore` (lines 1-4). Verify with
+  `git check-ignore -v .env` before committing if you are ever uncertain.
+- **Never paste real DB credentials anywhere public.** That includes issues, PRs,
+  commit messages, doc files, screenshots, screen recordings, chat tools, and AI
+  agent prompts. If a credential was pasted, treat it as compromised and rotate.
+- **Use a unique password.** Even though the port is loopback-only, do not reuse a
+  password from any other system. Local-only does not mean impact-free.
+
+## Removing it entirely
+
+If you decide you do not want this optional helper:
+
+```bash
+docker compose -f docker-compose.postgres.yml down -v
+rm docker-compose.postgres.yml docs/dev-postgres.md
+# remove POSTGRES_PASSWORD and DB_URL lines from .env and .env.example
+```
+
+ClaudeMaxPower will continue to function — no skill, hook, or example currently
+depends on Postgres.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -146,7 +146,7 @@ if [ -f ".env" ]; then
   check_env_placeholder "DB_URL" "postgresql://postgres:change-me-local-only@127.0.0.1:5432/claudemaxpower" \
     "examples and workflows that read DB_URL (see docs/dev-postgres.md)" || UNFILLED=$((UNFILLED + 1))
   check_env_placeholder "POSTGRES_PASSWORD" "change-me-local-only" \
-    "docker-compose.postgres.yml refuses to start with the placeholder password" || UNFILLED=$((UNFILLED + 1))
+    "optional local Postgres setup; replace this placeholder before starting docker-compose.postgres.yml" || UNFILLED=$((UNFILLED + 1))
 
   if [ "$UNFILLED" -eq 0 ]; then
     ok ".env values look filled (no known placeholders detected)."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -143,8 +143,10 @@ if [ -f ".env" ]; then
     "/fix-issue, /review-pr, MCP GitHub integration (auth will fail)" || UNFILLED=$((UNFILLED + 1))
   check_env_placeholder "DEFAULT_REPO" "your-username/your-repo" \
     "skills that default to a repo when --repo is omitted" || UNFILLED=$((UNFILLED + 1))
-  check_env_placeholder "DB_URL" "postgresql://user:password@localhost:5432/mydb" \
-    "examples and workflows that read DB_URL" || UNFILLED=$((UNFILLED + 1))
+  check_env_placeholder "DB_URL" "postgresql://postgres:change-me-local-only@127.0.0.1:5432/claudemaxpower" \
+    "examples and workflows that read DB_URL (see docs/dev-postgres.md)" || UNFILLED=$((UNFILLED + 1))
+  check_env_placeholder "POSTGRES_PASSWORD" "change-me-local-only" \
+    "docker-compose.postgres.yml refuses to start with the placeholder password" || UNFILLED=$((UNFILLED + 1))
 
   if [ "$UNFILLED" -eq 0 ]; then
     ok ".env values look filled (no known placeholders detected)."


### PR DESCRIPTION
## Summary

Add an optional local-development Postgres helper without making Postgres a project dependency.

- `docker-compose.postgres.yml` (new, repo root) — Postgres 16, loopback-only port binding (`127.0.0.1:5432:5432`), named volume `claudemaxpower_pgdata`, `POSTGRES_PASSWORD` required from `.env` (no hardcoded default; container refuses to start if unset).
- `docs/dev-postgres.md` (new) — setup, common commands, password rotation, security rules, removal. Explicit "not required" disclaimer at the top.
- `.env.example` — replace the stale `DB_URL=postgresql://user:password@localhost:5432/mydb` line with safe local-only placeholders (`POSTGRES_PASSWORD=change-me-local-only` and a matching `DB_URL`).
- `scripts/setup.sh` — keep the placeholder check in sync; add `POSTGRES_PASSWORD` check via existing `check_env_placeholder` helper. No new logic.

No app code added. ClaudeMaxPower continues to function exactly as before for anyone who does not start the container.

## Security decisions

- Host binding `127.0.0.1:5432:5432` only — never `0.0.0.0` or `5432:5432`.
- `POSTGRES_PASSWORD` sourced from `.env` via `${POSTGRES_PASSWORD:?...}` — no hardcoded fallback.
- Placeholder string is the literal `change-me-local-only` so it is self-documenting and obviously not a real value.
- `.env` was already gitignored (`.gitignore` lines 1-4) and is not touched.
- Docs explicitly forbid pasting real DB credentials into issues, PRs, commits, docs, screenshots, or chat.

## Test plan

- [x] `git diff --cached` reviewed — only the four intended files changed
- [x] Pattern-based secret scan of staged diff (`ghp_*`, `github_pat_*`, `MAX_*`-hex, `sk-*`, `AKIA*`, PEM blocks) — clean
- [x] Repo-wide pattern scan of tracked files — clean
- [x] `docker compose -f docker-compose.postgres.yml config` validates with `POSTGRES_PASSWORD` set
- [x] Compose refuses to start when `POSTGRES_PASSWORD` is unset (proves the no-default guarantee)
- [x] `bash scripts/setup.sh` reports `POSTGRES_PASSWORD` placeholder warning as expected; no secrets printed
- [x] `bash scripts/test-hooks.sh` — 12/12 pass
- [x] `bash scripts/validate-skills.sh` — 17/17 pass
- [ ] Reviewer confirms: no real credentials anywhere in the diff
- [ ] Reviewer confirms: docs make clear that Postgres is optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)