### PR TITLE
fix(commands): sweep stale slash-command wrappers in generator

### DIFF
--- a/.claude/commands/brainstorming.md
+++ b/.claude/commands/brainstorming.md
@@ -1,9 +1,0 @@
----
-description: Collaborative design refinement through Socratic questioning before any implementation
-argument-hint: --topic <value> [--visual <value>]
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep, TaskCreate, TaskUpdate
----
-
-Read `skills/brainstorming.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/finish-branch.md
+++ b/.claude/commands/finish-branch.md
@@ -1,9 +1,0 @@
----
-description: Completes development work — verifies tests pass, presents merge/PR/keep/discard options, cleans up worktrees.
-argument-hint: [--base <value>]
-allowed-tools: Bash, Read, Grep, Glob
----
-
-Read `skills/finish-branch.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/gen-commit-message.md
+++ b/.claude/commands/gen-commit-message.md
@@ -1,0 +1,8 @@
+---
+description: Use when user has staged changes and asks for a commit message, says "what should the commit message be", or types /gen-commit-message. Reads `git diff --staged` and proposes a Conventional Commits message (feat/fix/docs/refactor/test/chore).
+allowed-tools: Bash, Read
+---
+
+Read `skills/gen-commit-message.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/pre-commit.md
+++ b/.claude/commands/pre-commit.md
@@ -1,8 +1,0 @@
----
-description: Intelligent pre-commit check — inspects staged changes for secrets, style issues, debug statements, and generates a conventional commit message.
-allowed-tools: Bash, Read, Grep
----
-
-Read `skills/pre-commit.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/subagent-dev.md
+++ b/.claude/commands/subagent-dev.md
@@ -1,9 +1,0 @@
----
-description: Execute a plan with a fresh subagent per task and two-stage review (spec then quality)
-argument-hint: --plan <value> [--worktree <value>]
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, TaskCreate, TaskUpdate
----
-
-Read `skills/subagent-dev.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/superpowers-redirect.md
+++ b/.claude/commands/superpowers-redirect.md
@@ -1,0 +1,8 @@
+---
+description: Use when user types /brainstorming, /writing-plans, /subagent-dev, /tdd-loop, /systematic-debugging, /using-worktrees, or /finish-branch — these moved to the Superpowers plugin. Routes the user to the canonical /superpowers:* command.
+allowed-tools: Read
+---
+
+Read `skills/superpowers-redirect.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
+
+User arguments: $ARGUMENTS

--- a/.claude/commands/systematic-debugging.md
+++ b/.claude/commands/systematic-debugging.md
@@ -1,9 +1,0 @@
----
-description: Four-phase root cause debugging process. Never propose a fix without a failing test and a verified root cause.
-argument-hint: --issue <value> [--file <value>]
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep
----
-
-Read `skills/systematic-debugging.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/tdd-loop-lite.md
+++ b/.claude/commands/tdd-loop-lite.md
@@ -1,9 +1,0 @@
----
-description: Autonomous TDD loop — writes failing tests from a spec, then iterates on implementation until all tests are green. Stops at 10 iterations. Simpler TDD loop with 10-iteration cap — for use cases where the full strict TDD is overkill. For strict TDD with mandatory RED verification and iron-law enforcement, use /tdd-loop.
-argument-hint: --spec <value> --file <value> [--test-file <value>]
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep
----
-
-Read `skills/tdd-loop-lite.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/tdd-loop.md
+++ b/.claude/commands/tdd-loop.md
@@ -1,9 +1,0 @@
----
-description: Strict Test-Driven Development — iron law enforcement, mandatory RED verification, anti-rationalization guardrails. Write the test first, watch it fail, write minimal code to pass.
-argument-hint: --spec <value> --file <value> [--test-file <value>]
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep
----
-
-Read `skills/tdd-loop.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/using-worktrees.md
+++ b/.claude/commands/using-worktrees.md
@@ -1,9 +1,0 @@
----
-description: Creates an isolated git worktree workspace before implementation. Systematic directory selection plus safety verification.
-argument-hint: --branch <value> [--location <value>]
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob
----
-
-Read `skills/using-worktrees.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/.claude/commands/writing-plans.md
+++ b/.claude/commands/writing-plans.md
@@ -1,9 +1,0 @@
----
-description: Break an approved spec into bite-sized, subagent-executable implementation tasks
-argument-hint: --spec <value> [--output <value>]
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep, TaskCreate, TaskUpdate
----
-
-Read `skills/writing-plans.md` in this repository and execute its workflow verbatim. Parse any arguments the user passed below and bind them to the skill's declared arguments before running.
-
-User arguments: $ARGUMENTS

--- a/scripts/generate-commands.py
+++ b/scripts/generate-commands.py
@@ -18,6 +18,12 @@ from pathlib import Path
 SKILLS_DIR = Path("skills")
 CMD_DIR = Path(".claude/commands")
 
+# Signature of a wrapper this script previously generated. Used by the
+# stale-wrapper sweep to distinguish auto-generated wrappers from any
+# hand-written commands a user may have added to .claude/commands/.
+WRAPPER_SIGNATURE = "Read `skills/"
+WRAPPER_SIGNATURE_TAIL = "in this repository and execute its workflow verbatim."
+
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 NAME_RE = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
 DESC_RE = re.compile(r"^description:\s*(.+?)\s*$", re.MULTILINE)
@@ -84,17 +90,62 @@ def wrapper_text(skill_name: str, meta: dict) -> str:
     return "\n".join(lines)
 
 
+def is_generated_wrapper(path: Path) -> tuple[bool, str | None]:
+    """Return (is_wrapper, referenced_skill_name) for files this script emits.
+
+    Identifies wrappers by the literal body line the generator writes. Hand-written
+    commands without that signature are left untouched.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return (False, None)
+    if WRAPPER_SIGNATURE not in text or WRAPPER_SIGNATURE_TAIL not in text:
+        return (False, None)
+    m = re.search(r"Read `skills/([A-Za-z0-9_.-]+)\.md`", text)
+    return (True, m.group(1) if m else None)
+
+
+def sweep_stale_wrappers(current_skill_names: set[str]) -> int:
+    """Remove wrappers whose source skill no longer exists.
+
+    Only deletes files this script previously generated (signature match).
+    Returns the count removed.
+    """
+    if not CMD_DIR.is_dir():
+        return 0
+    removed = 0
+    for cmd_file in sorted(CMD_DIR.glob("*.md")):
+        is_wrapper, referenced = is_generated_wrapper(cmd_file)
+        if not is_wrapper:
+            continue
+        if referenced and referenced not in current_skill_names:
+            cmd_file.unlink()
+            removed += 1
+            print(f"  [RM] /{referenced} -> {cmd_file} (source skill removed)")
+    return removed
+
+
 def main() -> int:
     if not SKILLS_DIR.is_dir():
         print(f"error: {SKILLS_DIR}/ not found. Run from project root.", file=sys.stderr)
         return 1
 
     CMD_DIR.mkdir(parents=True, exist_ok=True)
-    written = 0
-    for skill_file in sorted(SKILLS_DIR.glob("*.md")):
+
+    skill_files = sorted(SKILLS_DIR.glob("*.md"))
+    skill_metas: list[tuple[str, dict]] = []
+    for skill_file in skill_files:
         text = skill_file.read_text(encoding="utf-8")
         meta = parse_frontmatter(text)
         name = meta.get("name") or skill_file.stem
+        skill_metas.append((name, meta))
+
+    current_names = {name for name, _ in skill_metas}
+    removed = sweep_stale_wrappers(current_names)
+
+    written = 0
+    for name, meta in skill_metas:
         out = CMD_DIR / f"{name}.md"
         # newline="\n" prevents Python from translating \n to \r\n on Windows.
         # The repo's .gitattributes enforces LF for *.md, so without this the
@@ -104,6 +155,8 @@ def main() -> int:
         print(f"  [OK] /{name} -> {out}")
 
     print(f"\nGenerated {written} slash-command wrappers in {CMD_DIR}/")
+    if removed:
+        print(f"Removed {removed} stale wrapper(s).")
     return 0
 
 


### PR DESCRIPTION
## Summary

- Adds a stale-wrapper sweep to `scripts/generate-commands.py` so that wrappers in `.claude/commands/` whose source skill has been removed from `skills/` are deleted automatically on each setup run.
- Removes 9 currently-broken wrappers left behind by the skill audit in #34: `/brainstorming`, `/finish-branch`, `/pre-commit`, `/subagent-dev`, `/systematic-debugging`, `/tdd-loop`, `/tdd-loop-lite`, `/using-worktrees`, `/writing-plans`. Each was pointing at a `skills/<name>.md` that no longer exists, so invoking any of them would fail. The canonical replacements live in the Superpowers plugin under `/superpowers:*`, with `/superpowers-redirect` catching the old names.
- Commits the two wrappers (`gen-commit-message`, `superpowers-redirect`) that `setup.sh` had been regenerating into the working tree on every run without ever being checked in.

The sweep is signature-matched against the literal body line this script emits, so any hand-written commands a user has added to `.claude/commands/` are left untouched.

## Test plan

- [x] `bash scripts/setup.sh` — runs clean, idempotent on second invocation
- [x] `python3 scripts/generate-commands.py` — reports `Removed 9 stale wrapper(s)` on the first run after this change, then 0 on subsequent runs
- [x] `bash scripts/test-hooks.sh` — 12/12 pass, working-tree mutation guard green
- [x] `bash scripts/validate-skills.sh` — all 12 frontmatter checks pass
- [x] `.claude/commands/` now contains exactly the 8 wrappers matching `skills/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)