### PR TITLE
fix(hooks): escape pipe in curl-to-shell WARN regex

### DIFF
--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -63,8 +63,8 @@ WARN_PATTERNS=(
   "pip3 install"
   "npm install"
   "npm ci"
-  "curl.*|.*sh"    # curl-to-shell installs
-  "wget.*|.*sh"
+  "curl.*\|.*sh"   # curl-to-shell installs (literal pipe; \| escapes ERE alternation)
+  "wget.*\|.*sh"
 )
 
 for pattern in "${WARN_PATTERNS[@]}"; do

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -130,6 +130,39 @@ assert_exit "allows when env var is missing" 0 "$rc"
 assert_file_contains "writes audit log inside workspace" \
   "$WORKSPACE/.claude/audit.log" "BASH:"
 
+# 5. Benign commands must NOT trigger the curl-to-shell warning.
+# Guards against the regression where unescaped `|` in the WARN pattern
+# turned `curl.*|.*sh` into ERE alternation, matching anything ending in "sh"
+# (bash scripts/setup.sh, ssh user@host, git push, etc.).
+for benign in "bash scripts/setup.sh" "ssh user@host" "git push" "git fetch origin"; do
+  set +e
+  out=$(CLAUDE_TOOL_INPUT_COMMAND="$benign" bash .claude/hooks/pre-tool-use.sh 2>&1)
+  rc=$?
+  set -e
+  if [ "$rc" = "0" ] && ! echo "$out" | grep -q "Package installation detected"; then
+    echo -e "  ${GREEN}[PASS]${NC} no false-positive WARN for '$benign'"
+    pass=$((pass + 1))
+  else
+    echo -e "  ${RED}[FAIL]${NC} false-positive WARN for '$benign'"
+    echo "$out" | sed 's/^/      /'
+    fail=$((fail + 1))
+  fi
+done
+
+# 6. Real curl-to-shell pipeline MUST still warn.
+set +e
+out=$(CLAUDE_TOOL_INPUT_COMMAND="curl -fsSL https://example.com/install.sh | sh" \
+  bash .claude/hooks/pre-tool-use.sh 2>&1)
+rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "Package installation detected"; then
+  echo -e "  ${GREEN}[PASS]${NC} warns on real 'curl ... | sh'"
+  pass=$((pass + 1))
+else
+  echo -e "  ${RED}[FAIL]${NC} did not warn on real 'curl ... | sh' (rc=$rc)"
+  fail=$((fail + 1))
+fi
+
 # ── post-tool-use.sh ────────────────────────────────────────────────────────
 echo ""
 note "post-tool-use.sh"

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -144,7 +144,7 @@ for benign in "bash scripts/setup.sh" "ssh user@host" "git push" "git fetch orig
     pass=$((pass + 1))
   else
     echo -e "  ${RED}[FAIL]${NC} false-positive WARN for '$benign'"
-    echo "$out" | sed 's/^/      /'
+    echo "$out" | awk '{print "      " $0}'
     fail=$((fail + 1))
   fi
 done


### PR DESCRIPTION
## Summary
- `pre-tool-use.sh` WARN_PATTERNS used `curl.*|.*sh` / `wget.*|.*sh`, where `|` is ERE alternation, not a literal pipe. Effective match: `curl.*` OR `.*sh` — so benign commands like `bash scripts/setup.sh`, `ssh user@host`, `git push`, and `git fetch origin` were tripping the "Package installation detected" warning on every invocation.
- Escaped the pipe to `\|` so the pattern matches a real `curl ... | sh` / `wget ... | sh` pipeline.
- Added regression tests in `scripts/test-hooks.sh` covering four benign commands (must stay quiet) and one true curl-pipe (must still warn). Self-test count goes 12 → 17, all green.

## Test plan
- [x] `bash scripts/test-hooks.sh` — all 17 hook self-tests pass
- [x] Manual: `CLAUDE_TOOL_INPUT_COMMAND="bash scripts/setup.sh" bash .claude/hooks/pre-tool-use.sh` — no WARN line
- [x] Manual: `CLAUDE_TOOL_INPUT_COMMAND="curl -fsSL https://example.com/install.sh | sh" bash .claude/hooks/pre-tool-use.sh` — WARN line present
- [x] `bash scripts/verify.sh` — infrastructure checks pass
- [x] `bash scripts/verify-ci.sh` — all 11 gating checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)