### PR TITLE
fix(audit): two bugs found while running /max-power

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -33,9 +33,12 @@ fi
 # Session state file
 echo ""
 if [ -f ".estado.md" ]; then
-  echo -e "${GREEN}Previous session state found (.estado.md):${NC}"
+  # Show only the 3 most recent session entries. The full file accumulates
+  # indefinitely; loading all of it into context on every session is wasteful.
+  # `awk` slices at the first 3 "## Session:" headers.
+  echo -e "${GREEN}Previous session state found (.estado.md, most recent 3):${NC}"
   echo "---"
-  cat .estado.md
+  awk '/^## Session:/ {n++} n>3 {exit} {print}' .estado.md
   echo "---"
 else
   echo "No previous session state (.estado.md not found). Starting fresh."

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -19,8 +19,12 @@ echo "[stop hook] Saving session state to $ESTADO_FILE..."
 # Claude Code will have already written a summary to CLAUDE_STOP_HOOK_SUMMARY if available
 SUMMARY="${CLAUDE_STOP_HOOK_SUMMARY:-}"
 
+# Skip empty summaries entirely. Writing a placeholder on every session end
+# accumulates noise (89 such entries in this repo's history) that session-start.sh
+# then loads back into context. A session with nothing to record is fine.
 if [ -z "$SUMMARY" ]; then
-  SUMMARY="Session ended at $TIMESTAMP. No summary provided."
+  echo -e "${YELLOW}[stop hook] No summary provided — skipping write to $ESTADO_FILE.${NC}"
+  exit 0
 fi
 
 # Prepend new entry (most recent first)

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -197,7 +197,8 @@ assert_exit "exits 0 with summary" 0 "$rc"
 assert_file_contains "writes summary to workspace .estado.md" \
   "$WORKSPACE/.estado.md" "cmp-test-hooks: synthetic session"
 
-# 2. Missing summary → exit 0, file appended with default text
+# 2. Missing summary → exit 0, no write (placeholder entries used to flood
+#    .estado.md; now stop.sh skips silently when no real summary was provided).
 set +e
 unset CLAUDE_STOP_HOOK_SUMMARY
 bash .claude/hooks/stop.sh >/dev/null 2>&1

--- a/skills/max-power.md
+++ b/skills/max-power.md
@@ -72,7 +72,10 @@ Record `CMP_INSTALLED=yes|no`.
 Count source files that are not part of ClaudeMaxPower:
 
 ```bash
-# Rough heuristic — count files outside .claude, skills, docs, scripts, workflows
+# Rough heuristic — count files outside .claude, skills, docs, scripts, workflows.
+# Use `*/X/*` (not `./X/*`) so nested vendor/build dirs are also excluded —
+# a project with sub-package node_modules or examples/.venv otherwise drowns
+# the count and forces a false `existing` classification.
 find . -type f \
   -not -path './.git/*' \
   -not -path './.claude/*' \
@@ -80,8 +83,12 @@ find . -type f \
   -not -path './docs/*' \
   -not -path './scripts/*' \
   -not -path './workflows/*' \
-  -not -path './node_modules/*' \
-  -not -path './.venv/*' \
+  -not -path '*/node_modules/*' \
+  -not -path '*/.venv/*' \
+  -not -path '*/__pycache__/*' \
+  -not -path '*/dist/*' \
+  -not -path '*/build/*' \
+  -not -path '*/target/*' \
   | wc -l
 ```
 


### PR DESCRIPTION
## Summary

Two real bugs surfaced by running the `/max-power` workflow end-to-end on this repo. Each fix is in its own commit so a future bisect lands on a focused change.

- **`fix(hooks): stop .estado.md placeholder bloat`** — `stop.sh` wrote a `"No summary provided"` entry on every session-end with no explicit summary, and `session-start.sh` `cat`-ed the full file back into context each new session. On this repo: **89 placeholder entries, 534 lines, all noise**, reloaded every startup. `stop.sh` now exits silently when no summary is set; `session-start.sh` shows only the 3 most-recent `## Session:` entries via `awk`; `test-hooks.sh` comment updated to match the new contract.
- **`fix(skills): exclude nested vendor dirs in max-power find heuristic`** — Step 1.3's new-vs-existing heuristic excluded only root-level `./node_modules/*` and `./.venv/*`. On this repo `examples/todo-app/.venv` made the count **2042** (structurally broken). Switched to `*/node_modules/*`, `*/.venv/*`, plus `__pycache__`, `dist`, `build`, `target`. New count: **44** — same correct classification, but now meaningful.

## Test plan

- [x] `bash scripts/test-hooks.sh` — 16/16 PASS (mutation guard auto-skipped on clean tree, pre-existing)
- [x] `bash scripts/validate-skills.sh` — all skills + agents PASS
- [x] Local `.estado.md` reset to fresh header (gitignored, no working-tree impact)
- [ ] Verify in a fresh session that `session-start.sh` shows only the last 3 entries
- [ ] Verify `stop.sh` no longer appends when ended without a summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)