### PR TITLE
fix(audit): two bugs found while running /max-power

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,10 @@ change is "trivial" when a reviewer would not ask "why?" about it.
 
 These apply to every PR:
 
-1. **No production code without a failing test first.** Run `/tdd-loop` for any new
-   behavior — write the test, watch it fail, write the minimal code to pass.
+1. **No production code without a failing test first.** Run
+   `/superpowers:test-driven-development` for any new behavior — write the test, watch it
+   fail, write the minimal code to pass. (Install the Superpowers plugin with
+   `/plugin install superpowers@claude-plugins-official` if you haven't already.)
 2. **No implementation without an approved spec.** Use `/brainstorming` for non-trivial
    work and link the spec from your PR.
 3. **No fixes without root-cause investigation.** Use `/systematic-debugging` for any bug
@@ -119,7 +121,9 @@ Before opening a PR:
 
 - Branch off the latest `main` (`git fetch origin && git rebase origin/main` — only on
   branches you have not pushed yet, or use a merge if you have).
-- Run `/pre-commit` to scan for secrets, debug statements, and large files.
+- The `.claude/hooks/pre-commit-check.sh` hook runs automatically before every `git commit`
+  — it scans staged changes for secrets (blocking), debug statements, large files, and
+  linter issues (all warnings). No manual invocation needed; just run `git commit`.
 - Run any tests that touch your changes (`pytest examples/todo-app/tests/`,
   `bash scripts/test-hooks.sh`, `bash scripts/validate-skills.sh`).
 - Make sure `git status` is clean and you are committing only the intended files.

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -207,16 +207,25 @@ else
 fi
 
 # --- 5. Structure ---
+# This list must stay in lock-step with .github/workflows/ci.yml's check-structure
+# job. Any file added/removed there should be mirrored here so a local green run
+# matches CI. The drift this script previously had (kept stale tdd-loop.md /
+# pre-commit.md while CI moved on to pre-commit-check.sh + gen-commit-message.md
+# + superpowers-redirect.md) caused a false `1 of 11 gating checks failed` on
+# clean main — the exact "local says red, CI says green" inversion this script
+# exists to prevent.
 sec "Verify Project Structure"
 REQUIRED=(
   "CLAUDE.md" "README.md" "LICENSE" ".env.example" ".gitignore"
   ".claude/settings.json"
   ".claude/hooks/session-start.sh" ".claude/hooks/pre-tool-use.sh"
-  ".claude/hooks/post-tool-use.sh" ".claude/hooks/stop.sh"
+  ".claude/hooks/post-tool-use.sh" ".claude/hooks/pre-commit-check.sh"
+  ".claude/hooks/stop.sh"
   ".claude/agents/code-reviewer.md" ".claude/agents/security-auditor.md"
   ".claude/agents/doc-writer.md"
   "skills/fix-issue.md" "skills/review-pr.md" "skills/refactor-module.md"
-  "skills/tdd-loop.md" "skills/pre-commit.md" "skills/generate-docs.md"
+  "skills/gen-commit-message.md" "skills/superpowers-redirect.md"
+  "skills/generate-docs.md"
   "workflows/batch-fix.sh" "workflows/parallel-review.sh"
   "workflows/mass-refactor.sh" "workflows/dependency-graph.sh"
   "mcp/github-config.json" "mcp/sentry-config.json"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -74,8 +74,14 @@ for hook in session-start pre-tool-use post-tool-use stop; do
 done
 
 # Skills
+# Must match the REQUIRED list in .github/workflows/ci.yml (check-structure job).
+# /tdd-loop and /pre-commit were removed when the Superpowers methodology was
+# inlined and the deterministic pre-commit checks moved into a hook:
+#   - TDD lives upstream at /superpowers:test-driven-development
+#   - /pre-commit's deterministic part → .claude/hooks/pre-commit-check.sh
+#   - /pre-commit's LLM part         → skills/gen-commit-message.md
 section "Skills"
-for skill in fix-issue review-pr refactor-module tdd-loop pre-commit generate-docs; do
+for skill in fix-issue review-pr refactor-module gen-commit-message superpowers-redirect generate-docs; do
   f="skills/${skill}.md"
   if [ -f "$f" ]; then
     ok "$f: found"
@@ -105,13 +111,14 @@ fi
 
 # Python example tests
 # NOTE: examples/todo-app ships with 3 INTENTIONAL bugs as fixtures for the
-# /fix-issue, /tdd-loop, and /pre-commit skill demos. By default, failures here
-# are informational and do NOT count against installation verification.
-# Set VERIFY_STRICT_EXAMPLES=1 to treat them as hard failures (legacy behaviour).
+# /fix-issue skill demo and the upstream /superpowers:test-driven-development
+# loop. By default, failures here are informational and do NOT count against
+# installation verification. Set VERIFY_STRICT_EXAMPLES=1 to treat them as
+# hard failures (legacy behaviour).
 section "Example App (intentional bugs — informational)"
 if [ -d "examples/todo-app/tests" ]; then
   echo -e "${YELLOW}ℹ${NC} examples/todo-app contains 3 intentional bugs used to demonstrate"
-  echo -e "${YELLOW}ℹ${NC} the /fix-issue, /tdd-loop, and /pre-commit skills."
+  echo -e "${YELLOW}ℹ${NC} the /fix-issue skill and the TDD / pre-commit-hook workflow."
   echo -e "${YELLOW}ℹ${NC} See examples/todo-app/README.md and examples/todo-app/CLAUDE.md."
 
   if python3 -m pytest examples/todo-app/tests -q --tb=line 2>/dev/null; then


### PR DESCRIPTION
## Summary

Third `/max-power` audit pass. Two bugs surfaced while running the workflow on a clean main; both are independent, contained, and shipped here as separate commits.

### 1. Local verifiers disagreed with CI on `main`

`scripts/verify.sh` and `scripts/verify-ci.sh` still required `skills/tdd-loop.md` and `skills/pre-commit.md`. Those files were intentionally removed when the Superpowers methodology was inlined (TDD → `/superpowers:test-driven-development`) and the `/pre-commit` skill was replaced by the `pre-commit-check.sh` hook + `skills/gen-commit-message.md`. `.github/workflows/ci.yml` was updated correctly at that time; the two local mirror scripts were left stale, producing a misleading `1 of 11 gating checks failed` on a clean `main` — the exact "local says red, CI says green" inversion `verify-ci.sh` exists to prevent.

Both scripts now match CI's required-file list verbatim and pass cleanly.

### 2. CONTRIBUTING.md PR checklist invoked deleted skills

Two contributor-facing instructions referenced slash commands that no longer exist in this repo:
- Iron law #1: "Run `/tdd-loop` for any new behavior." → updated to `/superpowers:test-driven-development` with a one-line plugin-install hint.
- PR checklist: "Run `/pre-commit` to scan for secrets, debug statements, and large files." → replaced with the actual current behavior (the `pre-commit-check.sh` hook fires automatically on every `git commit`).

These were the most concrete actionable lines in `CONTRIBUTING.md` — the first specific instructions a new contributor reads — and both produced broken behavior on a fresh checkout.

## Test plan

- [x] `bash scripts/test-hooks.sh` → 21/21 pass
- [x] `bash scripts/validate-skills.sh` → 12/12 pass
- [x] `bash scripts/verify.sh` → All infrastructure checks passed
- [x] `bash scripts/verify-ci.sh` → All 11 gating checks passed — local matches CI
- [x] Pre-commit hook fires on the commits in this PR (no secrets, no debug statements, no large files)
- [ ] CI green on the PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)