### PR TITLE
fix(audit): sweep stale slash-command refs found while running /max-power

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,9 @@ before opening a non-trivial PR.
 
 - **Report a bug** — open a GitHub issue using the `bug_report` template.
 - **Propose a feature or new skill** — open an issue using the `feature_request` template
-  and, ideally, run `/brainstorming` to produce a spec before writing code.
+  and, ideally, run `/superpowers:brainstorming` to produce a spec before writing code
+  (install the Superpowers plugin with `/plugin install superpowers@claude-plugins-official`
+  if you haven't already).
 - **Improve docs** — small fixes (typos, broken links, clarifications) are welcome as
   direct PRs. Larger structural changes deserve an issue first.
 - **Report a security issue** — do **not** use public issues. See [`SECURITY.md`](SECURITY.md).
@@ -44,13 +46,19 @@ and is the fastest way to verify your environment is correctly wired before you 
 ClaudeMaxPower is built around a deliberate pipeline. Please follow it for anything that
 isn't a one-line fix:
 
+The pipeline lives upstream in the Superpowers plugin (install once with
+`/plugin install superpowers@claude-plugins-official`):
+
 ```
-/brainstorming  → docs/specs/YYYY-MM-DD-<topic>-design.md   (hard gate: spec must be approved)
-/writing-plans  → docs/plans/YYYY-MM-DD-<topic>-plan.md     (bite-sized tasks)
-/using-worktrees → isolated branch workspace
-/subagent-dev   → fresh subagent per task + two-stage review
-/finish-branch  → merge / PR / keep / discard
+/superpowers:brainstorming                      → docs/specs/YYYY-MM-DD-<topic>-design.md   (hard gate: spec must be approved)
+/superpowers:writing-plans                      → docs/plans/YYYY-MM-DD-<topic>-plan.md     (bite-sized tasks)
+/superpowers:using-git-worktrees                → isolated branch workspace
+/superpowers:subagent-driven-development        → fresh subagent per task + two-stage review
+/superpowers:finishing-a-development-branch     → merge / PR / keep / discard
 ```
+
+If you type one of the legacy unqualified names (`/brainstorming`, `/writing-plans`, …)
+the `/superpowers-redirect` skill catches it and points you at the canonical command.
 
 Trivial changes (typos, obvious one-liners, formatting) are exempt from the spec gate. A
 change is "trivial" when a reviewer would not ask "why?" about it.
@@ -63,11 +71,11 @@ These apply to every PR:
    `/superpowers:test-driven-development` for any new behavior — write the test, watch it
    fail, write the minimal code to pass. (Install the Superpowers plugin with
    `/plugin install superpowers@claude-plugins-official` if you haven't already.)
-2. **No implementation without an approved spec.** Use `/brainstorming` for non-trivial
-   work and link the spec from your PR.
-3. **No fixes without root-cause investigation.** Use `/systematic-debugging` for any bug
-   whose cause isn't immediately obvious. A patch that makes the symptom disappear without
-   explaining why the symptom appeared is provisional at best.
+2. **No implementation without an approved spec.** Use `/superpowers:brainstorming` for
+   non-trivial work and link the spec from your PR.
+3. **No fixes without root-cause investigation.** Use `/superpowers:systematic-debugging`
+   for any bug whose cause isn't immediately obvious. A patch that makes the symptom
+   disappear without explaining why the symptom appeared is provisional at best.
 4. **No merging with failing tests.** CI must be green before merge.
 
 ## Coding conventions

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ claude
 /max-power
 
 # Or jump straight to your goal:
-/brainstorming --topic "new feature"
+/superpowers:brainstorming "new feature"   # requires: /plugin install superpowers@claude-plugins-official
 /fix-issue --issue 1 --repo michelbr84/ClaudeMaxPower
 /assemble-team --mode new-project --description "REST API for task management"
 ```
@@ -135,9 +135,9 @@ ClaudeMaxPower/
 | **Auto Dream** | Background memory consolidation — prunes stale entries, rebuilds index |
 | **Layered CLAUDE.md** | Project-wide + subfolder-specific Claude instructions with `@imports` |
 | **Hooks** | Auto-run tests after edits, block dangerous commands, save session state |
-| **Strict TDD** | Iron-law TDD (`/tdd-loop`) plus lite option (`/tdd-loop-lite`) for flexibility |
-| **Systematic Debugging** | 4-phase root-cause process — never patch a symptom |
-| **Git Worktree Isolation** | Safe parallel development with `/using-worktrees` and `/finish-branch` |
+| **Strict TDD** | Iron-law TDD via `/superpowers:test-driven-development` (install the Superpowers plugin) |
+| **Systematic Debugging** | 4-phase root-cause process via `/superpowers:systematic-debugging` — never patch a symptom |
+| **Git Worktree Isolation** | Safe parallel development with `/superpowers:using-git-worktrees` and `/superpowers:finishing-a-development-branch` |
 | **Sub-Agents** | Specialized agents (code reviewer, security auditor, doc writer, team coordinator) |
 | **Batch Workflows** | Fix multiple issues, mass-refactor, Writer/Reviewer pattern with worktrees |
 | **MCP Integrations** | Claude reads GitHub issues and Sentry errors directly |
@@ -181,10 +181,10 @@ for the merged pipeline, decision tables, and migration notes.
 
 **Four Iron Laws** enforced by the skills:
 
-1. No production code without a failing test first (`/tdd-loop`)
-2. No implementation without an approved spec (`/brainstorming` hard gate)
-3. No fixes without root-cause investigation (`/systematic-debugging`)
-4. No merging with failing tests (`/finish-branch` verification)
+1. No production code without a failing test first (`/superpowers:test-driven-development`)
+2. No implementation without an approved spec (`/superpowers:brainstorming` hard gate)
+3. No fixes without root-cause investigation (`/superpowers:systematic-debugging`)
+4. No merging with failing tests (`/superpowers:finishing-a-development-branch` verification)
 
 Attribution: see [`ATTRIBUTION.md`](ATTRIBUTION.md).
 
@@ -196,16 +196,21 @@ Invoke any skill with `/skill-name [arguments]` inside Claude Code.
 
 **Pipeline skills (Superpowers methodology):**
 
+Install once with `/plugin install superpowers@claude-plugins-official`. The methodology
+skills then live under the `/superpowers:` namespace.
+
 | Skill | Command | Description |
 |-------|---------|-------------|
-| Brainstorming | `/brainstorming --topic "user-auth"` | Collaborative design → spec (hard gate) |
-| Writing Plans | `/writing-plans --spec docs/specs/...md` | Break spec into bite-sized tasks |
-| Subagent Dev | `/subagent-dev --plan docs/plans/...md` | Fresh subagent per task + two-stage review |
-| Systematic Debugging | `/systematic-debugging --issue "..."` | 4-phase root-cause process |
-| Finish Branch | `/finish-branch` | Merge / PR / keep / discard + worktree cleanup |
-| Using Worktrees | `/using-worktrees --branch feat/xxx` | Safe isolated git worktree |
-| TDD Loop | `/tdd-loop --spec "..." --file path` | Strict Red-Green-Refactor with iron law |
-| TDD Loop (Lite) | `/tdd-loop-lite --spec "..." --file path` | Simpler TDD loop (pre-integration version) |
+| Brainstorming | `/superpowers:brainstorming "user-auth"` | Collaborative design → spec (hard gate) |
+| Writing Plans | `/superpowers:writing-plans <spec-file>` | Break spec into bite-sized tasks |
+| Subagent Dev | `/superpowers:subagent-driven-development <plan>` | Fresh subagent per task + two-stage review |
+| Systematic Debugging | `/superpowers:systematic-debugging "..."` | 4-phase root-cause process |
+| Finish Branch | `/superpowers:finishing-a-development-branch` | Merge / PR / keep / discard + worktree cleanup |
+| Using Worktrees | `/superpowers:using-git-worktrees` | Safe isolated git worktree |
+| TDD | `/superpowers:test-driven-development` | Strict Red-Green-Refactor with iron law |
+
+If you type one of the legacy unqualified names (`/brainstorming`, `/tdd-loop`, etc.) the
+`/superpowers-redirect` skill catches it and points you at the canonical command.
 
 **ClaudeMaxPower native skills:**
 
@@ -216,8 +221,9 @@ Invoke any skill with `/skill-name [arguments]` inside Claude Code.
 | Fix Issue | `/fix-issue --issue 1 --repo owner/repo` | Read issue → failing test → fix → PR |
 | Review PR | `/review-pr --pr 42 --repo owner/repo` | Structured review → post comment via gh |
 | Refactor Module | `/refactor-module --file src/foo.py --goal "..."` | Safe refactor with test baseline |
-| Pre-Commit | `/pre-commit` | Scan staged files for secrets, debug code, style |
+| Gen Commit Message | `/gen-commit-message` | Read staged diff, propose a Conventional Commits message (the deterministic secret / debug / large-file / linter checks now run automatically via the `pre-commit-check.sh` hook) |
 | Generate Docs | `/generate-docs --dir src/` | Auto-generate API docs from source |
+| Superpowers Redirect | `/superpowers-redirect` | Catches legacy `/brainstorming`-style names and points you at the canonical `/superpowers:*` |
 
 ---
 
@@ -303,7 +309,9 @@ MIT — see [LICENSE](LICENSE)
 
 1. Fork the repo
 2. Create a branch: `git checkout -b feat/your-feature`
-3. Run `/pre-commit` before committing
+3. `git commit` — the `pre-commit-check.sh` hook automatically scans staged changes for
+   secrets (blocking), debug statements, large files, and linter issues (warnings); use
+   `/gen-commit-message` if you want help drafting a Conventional Commits message
 4. Open a PR — the `review-pr` skill will help review it
 
 Issues and ideas welcome at [GitHub Issues](https://github.com/michelbr84/ClaudeMaxPower/issues).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,27 +86,39 @@ new project.
 
 ### Try the pipeline on a feature
 
+The pipeline skills live upstream in the Superpowers plugin. Install once with
+`/plugin install superpowers@claude-plugins-official`, then:
+
 ```bash
 # 1. Brainstorm the design (hard gate: produces an approved spec)
-/brainstorming --topic "task search"
+/superpowers:brainstorming "task search"
 
 # 2. Break the spec into bite-sized tasks
-/writing-plans --spec docs/specs/2026-04-17-task-search-design.md
+/superpowers:writing-plans docs/specs/2026-04-17-task-search-design.md
 
 # 3. Execute with fresh subagents + two-stage review
-/subagent-dev --plan docs/plans/2026-04-17-task-search-plan.md
+/superpowers:subagent-driven-development docs/plans/2026-04-17-task-search-plan.md
 
 # 4. Finish: merge, PR, or keep
-/finish-branch
+/superpowers:finishing-a-development-branch
 ```
+
+If you forget the prefix and type the legacy unqualified name (`/brainstorming`,
+`/tdd-loop`, etc.) the `/superpowers-redirect` skill catches it and tells you the
+canonical command.
 
 ### Or try a single-purpose skill
 
 ```bash
-/pre-commit
+/gen-commit-message
 ```
 
-This runs a pre-commit check on your staged files. Since you're in a fresh clone with nothing staged, it will tell you nothing is staged — that's correct.
+This reads `git diff --staged` and proposes a Conventional Commits message. Since you're
+in a fresh clone with nothing staged, it will tell you nothing is staged — that's correct.
+
+(The deterministic pre-commit checks — secrets, debug statements, large files, linter — run
+automatically via the `pre-commit-check.sh` hook on every `git commit`; no skill invocation
+needed.)
 
 ### Run the example tests
 

--- a/examples/todo-app/README.md
+++ b/examples/todo-app/README.md
@@ -5,9 +5,9 @@ A minimal Python CLI todo list with **3 intentional bugs** — used as a testbed
 ## Purpose
 
 This app exists to demonstrate:
-- `fix-issue` skill — fixing GitHub issues with TDD
-- `tdd-loop` skill — adding new features test-first
-- `pre-commit` skill — catching issues before committing
+- `/fix-issue` skill — fixing GitHub issues with TDD
+- `/superpowers:test-driven-development` (upstream Superpowers) — adding new features test-first
+- the `pre-commit-check.sh` hook — catches secrets / debug code / large files automatically before every `git commit`, with `/gen-commit-message` for the message itself
 
 ## The Bugs (for skill demonstrations)
 
@@ -32,9 +32,12 @@ You'll see the 3 buggy tests fail. That's expected — use the skills to fix the
 # 1. Run fix-issue skill to fix bug #1
 /fix-issue --issue 1 --repo your-username/ClaudeMaxPower
 
-# 2. Run tdd-loop to add a "search tasks" feature
-/tdd-loop --spec "Add a search_tasks(query) function that returns tasks whose title contains the query string (case-insensitive)" --file src/todo.py
+# 2. Run the upstream Superpowers TDD loop to add a "search tasks" feature
+#    (one-time install: /plugin install superpowers@claude-plugins-official)
+/superpowers:test-driven-development "Add a search_tasks(query) function in src/todo.py that returns tasks whose title contains the query string (case-insensitive)"
 
-# 3. Run pre-commit before committing
-/pre-commit
+# 3. Commit — the pre-commit-check.sh hook runs automatically (secrets, debug
+#    statements, large files, linter). Use /gen-commit-message for the message.
+/gen-commit-message
+git commit
 ```

--- a/skills/assemble-team.md
+++ b/skills/assemble-team.md
@@ -33,11 +33,11 @@ core superpower — it turns Claude from a solo assistant into a coordinated eng
 
 ### Step 0: Brainstorming gate (spec check)
 
-**No implementation until spec is approved — this is the same hard gate enforced by `/brainstorming`.**
+**No implementation until spec is approved — this is the same hard gate enforced by `/superpowers:brainstorming`.**
 
 Before analyzing the project or composing any team, verify that the work has been scoped.
 
-**For `new-project` mode:** a design spec MUST exist under `docs/specs/`. If none exists, stop and instruct the user to run `/brainstorming --topic <feature>` first. This is a hard gate — do not proceed, do not spawn agents, do not plan tasks.
+**For `new-project` mode:** a design spec MUST exist under `docs/specs/`. If none exists, stop and instruct the user to run `/superpowers:brainstorming <feature>` first (install the Superpowers plugin with `/plugin install superpowers@claude-plugins-official` if not already installed). This is a hard gate — do not proceed, do not spawn agents, do not plan tasks.
 
 ```bash
 ls docs/specs/*-design.md 2>/dev/null
@@ -46,7 +46,7 @@ ls docs/specs/*-design.md 2>/dev/null
 - If the command returns one or more files, read the most recent design spec and use it as the source of truth for Step 2 onwards.
 - If the command returns nothing, respond to the user with:
 
-  > No design spec found in `docs/specs/`. Run `/brainstorming --topic <feature>` first to produce an approved spec, then re-run `/assemble-team`.
+  > No design spec found in `docs/specs/`. Run `/superpowers:brainstorming <feature>` first to produce an approved spec, then re-run `/assemble-team`. (Install the Superpowers plugin with `/plugin install superpowers@claude-plugins-official` if it isn't already installed.)
 
   Then stop. Do not continue to Step 1.
 


### PR DESCRIPTION
## Summary

- Running `/max-power` surfaced user-facing docs and one operational skill that still instruct users to run `/brainstorming`, `/writing-plans`, `/subagent-dev`, `/systematic-debugging`, `/using-worktrees`, `/finish-branch`, `/tdd-loop`, `/tdd-loop-lite`, or `/pre-commit` — all of which were removed from `skills/` when the Superpowers methodology was moved upstream and the deterministic `/pre-commit` checks moved into the `pre-commit-check.sh` hook (with the LLM portion split out to `/gen-commit-message`).
- Continues the sweep started by PRs #37/#38/#39, which patched the verify scripts and parts of `CONTRIBUTING.md`. This PR finishes the cleanup across the remaining user-facing surfaces.
- Highest-impact fix: `skills/assemble-team.md` Step 0 gate text and two error messages — the skill would otherwise tell the user to run a command that no longer exists.

## Affected files

- **`skills/assemble-team.md`** — Step 0 gate text + two user-facing error messages now point at `/superpowers:brainstorming <feature>` (with plugin install hint).
- **`README.md`** — quick-start example, capabilities table, four iron laws, Superpowers pipeline skills table (rebuilt with `/superpowers:*` names, dropped `/tdd-loop-lite` row since it isn't shipped under `skills/`, added install hint + redirect note), native-skills table (`Pre-Commit` row replaced with `/gen-commit-message` and `/superpowers-redirect` rows), and the Contributing section step 3.
- **`examples/todo-app/README.md`** — Purpose list and Demo Workflow now reference `/fix-issue`, `/superpowers:test-driven-development`, the `pre-commit-check.sh` hook, and `/gen-commit-message`.
- **`docs/getting-started.md`** — "Try the pipeline" tutorial rewritten with `/superpowers:*` commands; "Or try a single-purpose skill" now invokes `/gen-commit-message` and explains the automatic hook.
- **`CONTRIBUTING.md`** — feature-request prose, pipeline diagram, and iron laws #2/#3 now use `/superpowers:*` commands with install hint and redirect note.

Remaining matches of the legacy unqualified names are intentional: the redirect mapping in `skills/superpowers-redirect.md` and historical context such as "the old /pre-commit skill" in `skills/gen-commit-message.md` and `docs/hooks-guide.md`.

## Test plan

- [x] \`bash scripts/test-hooks.sh\` — 21/21 pass
- [x] \`bash scripts/validate-skills.sh\` — 12/12 pass
- [x] \`bash scripts/verify.sh\` — all infrastructure checks pass (todo-app fixture bugs still fail as designed)
- [ ] CI green on the PR
- [ ] Spot-check rendered Markdown on the PR page for the README skills tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)