### PR TITLE
fix(audit): retire phantom Auto Dream / bootstrap-prompt claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,20 +120,12 @@ Specialized agents are defined in `.claude/agents/`:
 - `doc-writer` — documentation generation with user memory
 - `team-coordinator` — orchestrates agent teams with task dependencies
 
-## Auto Dream (Memory Consolidation)
-
-ClaudeMaxPower includes Auto Dream — a background process that consolidates memory files.
-It runs automatically via the session-start hook when 24+ hours and 5+ sessions have passed
-since the last consolidation. See `docs/auto-dream-guide.md` for details.
-
 ## Documentation References
 
 - @docs/hooks-guide.md
 - @docs/skills-guide.md
 - @docs/agents-guide.md
 - @docs/agent-teams-guide.md
-- @docs/auto-dream-guide.md
 - @docs/batch-workflows.md
 - @docs/superpowers-integration.md
-- @docs/bootstrap-prompt.md
 - @ATTRIBUTION.md

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Turn Claude Code into a coordinated AI engineering team — with the full Superpowers methodology built in.**
 
 ClaudeMaxPower is a GitHub template that transforms Claude from a solo assistant into a full
-AI engineering team — with hooks, skills, persistent memory, Auto Dream memory consolidation,
+AI engineering team — with hooks, skills, persistent session state (via `.estado.md`),
 and an integrated adaptation of the obra/superpowers methodology (brainstorm → spec → plan →
 subagent-driven development with strict TDD → two-stage review → finish).
 
@@ -40,12 +40,6 @@ claude
 /fix-issue --issue 1 --repo michelbr84/ClaudeMaxPower
 /assemble-team --mode new-project --description "REST API for task management"
 ```
-
-### Already in a Claude session? Use the bootstrap prompt
-
-Copy the prompt from [`docs/bootstrap-prompt.md`](docs/bootstrap-prompt.md) into any Claude
-Code (or Cursor, Codex, Gemini) session — it will clone ClaudeMaxPower, install the
-optional Superpowers plugin, run setup, and present the pipeline menu.
 
 ---
 
@@ -113,11 +107,11 @@ ClaudeMaxPower/
 ├── CLAUDE.md              ← Project-wide Claude instructions (layered)
 ├── .claude/
 │   ├── settings.json      ← Hook config + Agent Teams enabled
-│   ├── hooks/             ← Automated guards, quality gates, Auto Dream
+│   ├── hooks/             ← Automated guards, quality gates, session state
 │   └── agents/            ← Specialized sub-agents with persistent memory
 ├── skills/                ← Reusable AI workflows (invoke with /skill-name)
 ├── workflows/             ← Batch automation scripts
-├── scripts/               ← Setup, verify, Auto Dream memory consolidation
+├── scripts/               ← Setup, verify, hook self-test, skill validation
 ├── mcp/                   ← MCP server configs (GitHub, Sentry)
 ├── examples/              ← Working demo projects
 └── docs/                  ← Detailed guides for every feature
@@ -132,7 +126,6 @@ ClaudeMaxPower/
 | **Superpowers Pipeline** | Brainstorm → spec → plan → subagent-driven dev → two-stage review → finish |
 | **One-Command Bootstrap** | `/max-power` installs, configures, and routes you to the right skill |
 | **Agent Teams** | Assemble coordinated teams of specialized agents with `/assemble-team` |
-| **Auto Dream** | Background memory consolidation — prunes stale entries, rebuilds index |
 | **Layered CLAUDE.md** | Project-wide + subfolder-specific Claude instructions with `@imports` |
 | **Hooks** | Auto-run tests after edits, block dangerous commands, save session state |
 | **Strict TDD** | Iron-law TDD (`/tdd-loop`) plus lite option (`/tdd-loop-lite`) for flexibility |
@@ -161,12 +154,6 @@ ClaudeMaxPower/
 │  │ (coordinator  │  │  (batch/      │  │  (GitHub/        │ │
 │  │  + teammates) │  │  parallel)    │  │   Sentry)        │ │
 │  └───────────────┘  └───────────────┘  └──────────────────┘ │
-│                                                               │
-│  ┌───────────────┐  ┌───────────────┐                        │
-│  │  Auto Dream   │  │   Memory      │                        │
-│  │  (consolidate │  │  (persistent  │                        │
-│  │   memories)   │  │   context)    │                        │
-│  └───────────────┘  └───────────────┘                        │
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -269,9 +256,7 @@ Agents are invoked by Claude as sub-sessions with specialized roles.
 
 - [Getting Started](docs/getting-started.md) — prerequisites, setup, first run
 - **[Superpowers Integration](docs/superpowers-integration.md)** — merged pipeline, decision tables
-- **[Bootstrap Prompt](docs/bootstrap-prompt.md)** — copy-paste activation for any Claude session
 - [Agent Teams Guide](docs/agent-teams-guide.md) — assembling and coordinating agent teams
-- [Auto Dream Guide](docs/auto-dream-guide.md) — memory consolidation system
 - [Hooks Guide](docs/hooks-guide.md) — how hooks work, how to customize them
 - [Skills Guide](docs/skills-guide.md) — using and writing skills
 - [Agents Guide](docs/agents-guide.md) — sub-agents and persistent memory

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,8 +58,7 @@ Examples of issues that ClaudeMaxPower considers in scope:
   `workflows/`, or `.claude/`.
 - A bypass of the `BLOCKED_PATTERNS` allow/deny list in `pre-tool-use.sh`
   that would let a clearly-malicious command through.
-- Supply-chain risks introduced by `scripts/setup.sh`, the bootstrap prompt,
-  or any auto-installed tool.
+- Supply-chain risks introduced by `scripts/setup.sh` or any auto-installed tool.
 
 ## Out of Scope
 
@@ -93,6 +92,5 @@ If you have installed ClaudeMaxPower into your own project:
 - Keep the hooks enabled and treat `pre-tool-use.sh`'s block-list as
   defense in depth, not the primary safety boundary
   (see `docs/hooks-guide.md`).
-- Run `bash scripts/test-hooks.sh` and `bash scripts/test-auto-dream.sh`
-  after customizing hooks or `auto-dream.sh`.
+- Run `bash scripts/test-hooks.sh` after customizing any hook script.
 - Prefer Claude Code's `plan` mode for risky or destructive work.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,7 +130,6 @@ ls workflows/             # Batch scripts
 ## What to Read Next
 
 - [Superpowers Integration](superpowers-integration.md) — the merged pipeline and decision tables
-- [Bootstrap Prompt](bootstrap-prompt.md) — copy-paste activator for any Claude session
 - [Hooks Guide](hooks-guide.md) — understand what fires automatically
 - [Skills Guide](skills-guide.md) — learn to use and write skills
 - [Agents Guide](agents-guide.md) — specialized sub-agents

--- a/docs/superpowers-integration.md
+++ b/docs/superpowers-integration.md
@@ -13,16 +13,16 @@ approach to building software with an AI collaborator. With over 157k stars on G
 time of this writing, it has become a reference point for structured Claude workflows.
 
 ClaudeMaxPower is a GitHub template that turns Claude Code into a coordinated AI engineering
-team. It ships with hooks (session-start, pre-tool-use, post-tool-use, stop), a skill library
-(`/fix-issue`, `/review-pr`, `/refactor-module`, `/pre-commit`, `/generate-docs`), specialized
-agents (`code-reviewer`, `security-auditor`, `doc-writer`, `team-coordinator`), Auto Dream
-memory consolidation, and Agent Teams (`/assemble-team`) with two operating modes:
-new-project and existing-project.
+team. It ships with hooks (session-start, pre-tool-use, pre-commit-check, post-tool-use, stop),
+a skill library (`/fix-issue`, `/review-pr`, `/refactor-module`, `/gen-commit-message`,
+`/generate-docs`), specialized agents (`code-reviewer`, `security-auditor`, `doc-writer`,
+`team-coordinator`), and Agent Teams (`/assemble-team`) with two operating modes: new-project
+and existing-project.
 
 The two projects merge naturally. Superpowers contributes a methodology — how work flows from
 idea to merged branch, with gates at each stage. ClaudeMaxPower contributes infrastructure —
-hooks, memory consolidation, team orchestration, and batch workflows. Integrating them gives
-a single template that enforces rigorous practice while automating the mechanical work around it.
+hooks, team orchestration, and batch workflows. Integrating them gives a single template that
+enforces rigorous practice while automating the mechanical work around it.
 
 The integration approach is to adapt and inline the relevant Superpowers skills directly into
 the ClaudeMaxPower repository. This keeps the template self-contained (no submodules, no
@@ -237,25 +237,23 @@ This rule is itself an iron-law variant of law #3 (no fixes without root-cause
 investigation), applied to the special case where the "report" comes from another
 LLM session rather than a human bug report.
 
-## 7. Memory Integration
+## 7. Session State Handoff
 
-Superpowers methodology interacts with ClaudeMaxPower's Auto Dream memory consolidation in
-predictable ways:
+Across sessions, ClaudeMaxPower preserves state through two mechanisms:
 
-- **Brainstorming decisions become project memories.** When a `/brainstorming` session lands
-  on a significant design decision ("we use JWT for auth, not sessions"), the decision is
-  recorded as a project-scoped memory. Auto Dream keeps these consolidated and deduplicated.
-- **Post-review feedback becomes feedback memories.** When `/subagent-dev`'s two-stage review
-  produces actionable feedback (style preferences, naming conventions, missing test patterns),
-  that feedback is captured for reuse in later sessions.
-- **Spec and plan file paths become reference memories.** The memory index tracks where the
-  current spec and plan live, so future sessions can resume without re-asking.
-- **Auto Dream prunes stale spec references.** Specs from archived or merged branches become
-  noise in memory. Auto Dream's staleness check flags them. Files older than 30 days or
-  references to branches that no longer exist are candidates for removal.
+- **`.estado.md`** is written by the `stop` hook at the end of each session and read by the
+  `session-start` hook at the beginning of the next one. The session-start hook surfaces only
+  the three most recent entries to keep the loaded context small; older entries remain in the
+  file for reference.
+- **Claude Code's own auto-memory** (under the user-level memory directory) is the canonical
+  store for user, feedback, project, and reference memories. ClaudeMaxPower does not maintain
+  a separate memory store and does not run any background consolidation process — anything you
+  see described elsewhere as "Auto Dream" is unbuilt and has been retired from the docs.
 
-Memory consolidation runs at session start when both conditions are met: 24+ hours since the
-last dream, and 5+ sessions since the last dream. See `docs/auto-dream-guide.md` for details.
+Superpowers methodology integrates with this in the obvious way: brainstorming outcomes land
+in `docs/specs/`, plans land in `docs/plans/`, the session summary that names them is written
+to `.estado.md`, and Claude Code's auto-memory captures durable user and project notes
+on its own schedule.
 
 ## 8. Hook Interactions
 
@@ -286,7 +284,7 @@ methodology runs.
 | Spec gate                 | Yes (`/brainstorming`)  | No                        | Yes, enforced in new-project mode     |
 | TDD rigor                 | Strict (iron law)       | Optional (`/tdd-loop-lite`)| Strict (`/tdd-loop`) + lite available|
 | Agent teams               | No                      | Yes (`/assemble-team`)    | Yes, with brainstorming gate          |
-| Memory consolidation      | No                      | Yes (Auto Dream)          | Yes, Superpowers-aware                |
+| Session-state handoff     | No                      | Yes (`.estado.md`)        | Yes (`.estado.md` + Claude Code auto-memory) |
 | Hooks (session/pre/post/stop) | No                  | Yes                       | Yes                                   |
 | Worktrees                 | Yes (`/using-worktrees`)| Partial (`parallel-review.sh`)| Yes (`/using-worktrees` + scripts)|
 | Two-stage review          | Yes (`/subagent-dev`)   | No                        | Yes                                   |
@@ -317,7 +315,7 @@ If you were using ClaudeMaxPower before this integration, here is what to expect
 - **New skills are additive.** `/brainstorming`, `/writing-plans`, `/subagent-dev`,
   `/systematic-debugging`, `/finish-branch`, and `/using-worktrees` are all new and do not
   interfere with existing workflows.
-- **Hooks, agents, Auto Dream, and workflow scripts are unchanged.** Your existing
+- **Hooks, agents, and workflow scripts are unchanged.** Your existing
   `.claude/settings.json`, `.claude/agents/`, and `workflows/` remain compatible.
 
 No manual migration steps are required. Pull the new version of the template and existing
@@ -335,12 +333,10 @@ adapted skills intact inherits the attribution requirement automatically.
 
 - obra/superpowers — [https://github.com/obra/superpowers](https://github.com/obra/superpowers)
 - ClaudeMaxPower — [https://github.com/michelbr84/ClaudeMaxPower](https://github.com/michelbr84/ClaudeMaxPower)
-- Bootstrap prompt — `docs/bootstrap-prompt.md`
 - Hooks guide — `docs/hooks-guide.md`
 - Skills guide — `docs/skills-guide.md`
 - Agents guide — `docs/agents-guide.md`
 - Agent Teams guide — `docs/agent-teams-guide.md`
-- Auto Dream guide — `docs/auto-dream-guide.md`
 - Batch workflows — `docs/batch-workflows.md`
 - Individual skill files in `skills/`
 - Attribution and license — `ATTRIBUTION.md`

--- a/skills/max-power.md
+++ b/skills/max-power.md
@@ -230,7 +230,7 @@ Native ClaudeMaxPower entry points:
   /superpowers-redirect            (when you type an old /brainstorming-style command)
 
 Governance hooks (auto-fire, no invocation needed):
-  - session-start hook       context restore + Auto Dream
+  - session-start hook       context restore (reads .estado.md)
   - pre-tool-use hook        blocks dangerous commands
   - pre-commit-check hook    secret/debug/large-file/linter scan before git commit
   - post-tool-use hook       auto-run tests on edit
@@ -265,9 +265,7 @@ so the field list and skill/hook inventories can be updated independently of thi
 - Skills: [`docs/skills-guide.md`](../docs/skills-guide.md)
 - Agents: [`docs/agents-guide.md`](../docs/agents-guide.md)
 - Agent teams: [`docs/agent-teams-guide.md`](../docs/agent-teams-guide.md)
-- Auto Dream: [`docs/auto-dream-guide.md`](../docs/auto-dream-guide.md)
 - Batch workflows: [`docs/batch-workflows.md`](../docs/batch-workflows.md)
-- Copy-paste bootstrap prompt: [`docs/bootstrap-prompt.md`](../docs/bootstrap-prompt.md)
 
 ## Success criteria
 

--- a/skills/references/max-power-status-dashboard.md
+++ b/skills/references/max-power-status-dashboard.md
@@ -14,7 +14,6 @@ Skills loaded      assemble-team, fix-issue, gen-commit-message, generate-docs,
                    max-power, refactor-module, review-pr, superpowers-redirect
 Hooks active       session-start, pre-tool-use, pre-commit-check, post-tool-use, stop
 Agent teams        enabled (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1)
-Auto Dream         configured (trigger: 24h + 5 sessions)
 Superpowers plugin <installed | not installed>
 Environment        <.env ok | .env missing placeholders>
 Next action        <recommended skill from Step 6>


### PR DESCRIPTION
## Summary

- Second-pass `/max-power` audit (sibling to #40) caught a different bug class: the docs prominently advertise two features that were never built and reference two doc files that don't exist.
- `docs/auto-dream-guide.md` (referenced 5×) and `docs/bootstrap-prompt.md` (referenced 6×) are absent — `@imports` in `CLAUDE.md` silently fail at session start.
- The advertised **Auto Dream** "background memory consolidation that runs automatically via the session-start hook when 24+ hours and 5+ sessions have passed" does not exist. \`grep "dream\|consolidat"\` across every hook and script returns zero matches; \`session-start.sh\` (73 lines, audited in full) does no dream work.
- Most concerning: \`SECURITY.md\` told users to run \`bash scripts/test-auto-dream.sh\` after customising \`auto-dream.sh\`. Neither file exists — that is misleading defensive guidance.

This PR retires the phantom claims across every live surface. Building the feature is out of scope for an audit pass; if you want it back, brainstorm and plan it as roadmap work.

## Changes

- **CLAUDE.md** — drop \`## Auto Dream\` section + the two broken \`@imports\`.
- **README.md** — drop the Auto Dream pitch line, the "Already in a Claude session? Use the bootstrap prompt" section, the Auto Dream row in Features, the Auto Dream + Memory row in the Architecture ASCII, the two broken doc links, and the misleading "Auto Dream" labels in the tree-comments.
- **docs/superpowers-integration.md** — §1 intro de-fictionalised; §7 "Memory Integration" rewritten as "Session State Handoff" describing the real mechanism (\`.estado.md\` + Claude Code's own auto-memory) with an explicit retraction note; §9 comparison-table row replaced with truthful "Session-state handoff"; §10 migration list de-listed; §12 references trimmed.
- **docs/getting-started.md** — drop broken Bootstrap Prompt entry.
- **skills/max-power.md** — Step 6.2 menu now reads "context restore (reads .estado.md)"; cross-references drop the two broken links.
- **skills/references/max-power-status-dashboard.md** — drop the "Auto Dream configured" template line.
- **SECURITY.md** — drop the bootstrap-prompt supply-chain bullet and the \`test-auto-dream.sh\` defensive bullet.

## Left in place intentionally

- \`docs/archive/implementation_plan.md\` — labelled "pre-pivot architecture", meant to capture history.
- \`docs/superpowers-integration.md\` §7 deliberately names "Auto Dream" once in a retraction sentence so future readers can grep and find the explicit "this was retired, not just renamed" note.

## Test plan

- [x] \`bash scripts/test-hooks.sh\` — 21/21 pass
- [x] \`bash scripts/validate-skills.sh\` — 12/12 pass
- [x] \`bash scripts/verify.sh\` — all infrastructure checks pass
- [ ] CI green on the PR
- [ ] Spot-check that the rendered README looks coherent without the Auto Dream feature row and architecture box

🤖 Generated with [Claude Code](https://claude.com/claude-code)