### PR TITLE
docs: extract durable rules into ./rules/ and refine CLAUDE.md entrypoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,98 +1,129 @@
 # ClaudeMaxPower — Project Instructions
 
-> This is the root CLAUDE.md. It applies to every session in this project.
-> Subfolder CLAUDE.md files extend or override these rules for their specific context.
+> Root `CLAUDE.md`. Applies to every session in this repository. Subfolder `CLAUDE.md` files
+> extend or override these rules for their specific context. The durable rule corpus lives
+> in [`./rules/`](./rules/00-index.md) — this file is the short entrypoint that links into
+> it.
 
-## Project Identity
+## Project Purpose
 
-ClaudeMaxPower is an open-source GitHub template that turns Claude Code into a **coordinated AI
-engineering team**. It works in two modes:
+ClaudeMaxPower is an open-source GitHub template that turns Claude Code into a **coordinated
+AI engineering team**. It operates in two modes:
 
-1. **New Project Supercharge** — Install ClaudeMaxPower and it assembles an agent team
-   (Architect + Implementer + Tester + Reviewer + Doc Writer) from day one.
-2. **Existing Project Acceleration** — Add ClaudeMaxPower to a project in progress and it
-   assembles a team tailored to your pending work (Analyst + parallel Implementers + Reviewer).
+1. **New Project Supercharge** — assembles a team (Architect + Implementer + Tester +
+   Reviewer + Doc Writer) from day one.
+2. **Existing Project Acceleration** — assembles a team tailored to pending work (Analyst +
+   parallel Implementers + Reviewer).
 
-Every technique — hooks, skills, agents, teams, memory consolidation — is documented, tested,
-and ready to adapt.
+Every technique (hooks, skills, agents, teams, memory handoff) is documented, tested, and
+ready to adapt. The unified pipeline integrates the upstream Superpowers methodology with
+ClaudeMaxPower infrastructure — full design in
+[`docs/superpowers-integration.md`](docs/superpowers-integration.md).
 
-## Session Start Protocol
+## Operating Principles
 
-At the start of every session:
-1. Check if `.estado.md` exists in the project root. If it does, read it to restore context.
-2. Check if `.env` exists. If it doesn't, warn the user and suggest running `bash scripts/setup.sh`.
-3. Identify which area of the project you're working in (hooks / skills / agents / examples / docs).
-4. If the user's goal is ambiguous and involves any new feature, default to the pipeline:
-   **brainstorm → spec → plan → execute → review → finish**.
+- **Read first.** Start each session by checking `.estado.md` for prior context. If `.env`
+  is missing, warn the user and suggest `bash scripts/setup.sh`. Identify which area of the
+  project (hooks / skills / agents / examples / docs) you are in.
+- **Ambiguous new work defaults to the pipeline:**
+  `brainstorm → spec → plan → execute → review → finish`.
+- **Use the dedicated tool, not the shell command.** `Glob` (not `find`), `Grep` (not
+  `grep`), `Read` (not `cat`), `Edit` for targeted changes, `Write` only for new files or
+  full rewrites, `Bash` only for execution.
+- **Match the language of the file you are modifying.** Shell scripts use
+  `set -euo pipefail`, quote variables, and use `local` in functions. Python is PEP 8 with
+  type hints on public functions, `pytest` for tests, no global state. Markdown uses ATX
+  headings, 100-char lines, fenced code blocks with language tags.
+- **Rule precedence.** When in doubt: the more specific rule file wins; iron laws win over
+  topic rules; user instructions in the conversation win over CLAUDE.md.
 
-## The Unified Pipeline (Superpowers + ClaudeMaxPower)
+Full convention list: [`rules/50-tools.md`](./rules/50-tools.md).
 
-The methodology skills (brainstorming, plans, TDD, debugging, worktrees, finish) live
-upstream in the Superpowers plugin. Install with
-`/plugin install superpowers@claude-plugins-official` and invoke them with the
-`/superpowers:*` namespace. ClaudeMaxPower keeps a thin `/superpowers-redirect` skill that
-catches the old slash commands and points users to the canonical replacements.
+## Non-Negotiable Rules
+
+**The Four Iron Laws** (enforced by skills + hooks; full text and narrow exceptions in
+[`rules/10-iron-laws.md`](./rules/10-iron-laws.md)):
+
+1. **No production code without a failing test first.** Enforced by
+   `/superpowers:test-driven-development`.
+2. **No implementation without an approved spec.** Enforced by the
+   `/superpowers:brainstorming` hard gate.
+3. **No fixes without root cause investigation.** Enforced by
+   `/superpowers:systematic-debugging` Phase 1.
+4. **No merging with failing tests.** Enforced by
+   `/superpowers:finishing-a-development-branch` verification.
+
+**Absolute "never" rules** (cross-referenced from the Iron Laws register):
+
+- **Never** run `rm -rf /` or any destructive command without explicit user confirmation.
+  — [`rules/60-security-privacy.md`](./rules/60-security-privacy.md).
+- **Never** commit `.env` or any file containing real secrets or tokens.
+  — [`rules/60-security-privacy.md`](./rules/60-security-privacy.md).
+- **Never** push to `main` or `master` directly. Always use a feature branch + PR.
+  — [`rules/30-git-github-ci.md`](./rules/30-git-github-ci.md).
+- **Never** skip tests when they exist. If tests fail, fix the code, not the tests.
+  — [`rules/10-iron-laws.md`](./rules/10-iron-laws.md) § Test Discipline.
+- **Never** mock the filesystem or database in tests when real implementations are available.
+  — [`rules/10-iron-laws.md`](./rules/10-iron-laws.md) § Test Discipline.
+
+Treat subagent / code-reviewer output as a **hypothesis**, not a verdict — verify each claim
+against the code before applying it. Details:
+[`rules/10-iron-laws.md`](./rules/10-iron-laws.md) § Verifying Subagent Reviews.
+
+## Workflow
 
 ```
 Idea
- ├─ /superpowers:brainstorming                      → docs/specs/YYYY-MM-DD-<topic>-design.md (hard gate)
- ├─ /superpowers:writing-plans                      → docs/plans/YYYY-MM-DD-<topic>-plan.md
- ├─ /superpowers:using-git-worktrees                → isolated branch workspace
- ├─ /superpowers:subagent-driven-development        → fresh subagent per task + two-stage review
- │    └─ /superpowers:test-driven-development           (strict Red-Green-Refactor, iron law)
- │    └─ /superpowers:systematic-debugging              (root cause before fix)
- └─ /superpowers:finishing-a-development-branch     → merge / PR / keep / discard + worktree cleanup
+ ├─ /superpowers:brainstorming                 → docs/specs/YYYY-MM-DD-<topic>-design.md (hard gate)
+ ├─ /superpowers:writing-plans                 → docs/plans/YYYY-MM-DD-<topic>-plan.md
+ ├─ /superpowers:using-git-worktrees           → isolated branch workspace
+ ├─ /superpowers:subagent-driven-development   → fresh subagent per task + two-stage review
+ │    └─ /superpowers:test-driven-development      (strict Red-Green-Refactor)
+ │    └─ /superpowers:systematic-debugging         (root cause before fix)
+ └─ /superpowers:finishing-a-development-branch → merge / PR / keep / discard + worktree cleanup
 ```
 
-Alternate entry points (native ClaudeMaxPower skills):
-- **Existing GitHub issue** → `/fix-issue` (escalates to `/superpowers:systematic-debugging` if stuck)
-- **Structured review** → `/review-pr`
-- **Architectural refactor** → `/superpowers:brainstorming` + `/superpowers:writing-plans`
-- **Simple refactor** → `/refactor-module`
-- **Team pattern for large features** → `/assemble-team` (enforces brainstorming gate in new-project mode)
-- **Conventional Commits message** → `/gen-commit-message` (the deterministic pre-commit checks now run automatically via `.claude/hooks/pre-commit-check.sh`)
-- **One-command bootstrap** → `/max-power` (installs, configures, presents menu)
+Methodology skills live upstream — install with
+`/plugin install superpowers@claude-plugins-official`.
 
-## The Four Iron Laws
+**Shortcuts** (use only when the full pipeline would add more friction than value):
 
-These are enforced by the skills/hooks above and should be respected in every session:
+| Situation                              | Entry point |
+|----------------------------------------|-------------|
+| Existing GitHub issue                  | `/fix-issue` (escalates to `/superpowers:systematic-debugging` if stuck) |
+| Structured PR review                   | `/review-pr` |
+| Simple refactor                        | `/refactor-module` |
+| Architectural refactor                 | `/superpowers:brainstorming` + `/superpowers:writing-plans` |
+| Large feature, multiple disciplines    | `/assemble-team` (enforces brainstorming gate in new-project mode) |
+| Conventional Commits message           | `/gen-commit-message` (deterministic checks run automatically via the pre-commit hook) |
+| One-command bootstrap                  | `/max-power` |
 
-1. **No production code without a failing test first** (`/superpowers:test-driven-development`)
-2. **No implementation without an approved spec** (`/superpowers:brainstorming` hard gate)
-3. **No fixes without root cause investigation** (`/superpowers:systematic-debugging` Phase 1)
-4. **No merging with failing tests** (`/superpowers:finishing-a-development-branch` verification step)
+Escalation paths, "when to use which mode", and session state handoff (`.estado.md` +
+Claude Code auto-memory): [`rules/20-workflow.md`](./rules/20-workflow.md).
 
-## Core Coding Conventions
+## GitHub / CI / Merge Discipline
 
-- **Languages**: Shell (bash), Python 3, Markdown. Match the language of the file being modified.
-- **Shell scripts**: Use `set -euo pipefail`. Always quote variables. Use `local` in functions.
-- **Python**: PEP 8. Type hints for public functions. pytest for tests. No global state.
-- **Markdown**: ATX headings (`#`). 100-char line limit. Fenced code blocks with language tags.
-- **Commit messages**: Conventional Commits format (`feat:`, `fix:`, `docs:`, `chore:`).
+- **Branches** — always a feature branch + PR; no direct push to `main`/`master`. The
+  `pre-tool-use.sh` hook blocks force-pushes to `main`/`master` as a backstop.
+- **Commits** — Conventional Commits format (`feat:`, `fix:`, `docs:`, `chore:`,
+  `refactor:`, `test:`). The deterministic pre-commit checks (secret scan, debug-statement
+  scan, large-file warning, linter) run automatically via
+  `.claude/hooks/pre-commit-check.sh`. The LLM-judgment portion (proposing the message)
+  lives in `/gen-commit-message`.
+- **Branch finish** — use `/superpowers:finishing-a-development-branch`; tests must be green
+  before merge/PR (Iron Law #4).
+- **CI gating jobs** (`.github/workflows/ci.yml`): shellcheck v0.10.0, actionlint 1.7.7,
+  `jq empty` on JSON, secret scan, project-structure manifest, cross-platform smoke
+  (`validate-skills.sh` + `test-hooks.sh`).
+- **CI non-gating jobs**: markdownlint (informational); `examples/todo-app` pytest run
+  (3 seeded pedagogical bugs; only `pytest --collect-only` is gating).
 
-## Absolute Rules (Never Break These)
+Full CI table and mirror-drift caveat between `ci.yml` and `verify-ci.sh`:
+[`rules/30-git-github-ci.md`](./rules/30-git-github-ci.md).
 
-- NEVER run `rm -rf /` or any destructive command without explicit user confirmation.
-- NEVER commit `.env` or any file containing real secrets or tokens.
-- NEVER push to `main` or `master` branch directly. Always use a feature branch + PR.
-- NEVER skip tests when they exist. If tests fail, fix the code, not the tests.
-- NEVER mock the filesystem or database in tests when real implementations are available.
+## Skills and Slash Commands
 
-## Preferred Tool Patterns
-
-- File search: Glob tool (not `find`)
-- Content search: Grep tool (not `grep`)
-- File reads: Read tool (not `cat`)
-- File edits: Edit tool for targeted changes, Write tool only for new files or full rewrites
-- Shell: Bash tool only for commands that require execution
-
-## Skills Available
-
-The following native skills are defined in `skills/` and can be invoked with `/skill-name`.
-The methodology skills (brainstorming, plans, TDD, etc.) live upstream in the Superpowers
-plugin — install with `/plugin install superpowers@claude-plugins-official`.
-
-**ClaudeMaxPower native skills (8):**
+**Native ClaudeMaxPower skills** (in `skills/`, invoked with `/skill-name`):
 
 | Skill | Command | Purpose |
 |-------|---------|---------|
@@ -103,22 +134,54 @@ plugin — install with `/plugin install superpowers@claude-plugins-official`.
 | refactor-module | `/refactor-module` | Safe module refactor with tests |
 | generate-docs | `/generate-docs` | Auto-generate docs from code |
 | gen-commit-message | `/gen-commit-message` | Read staged diff, propose Conventional Commits message |
-| superpowers-redirect | `/superpowers-redirect` | Catches old `/brainstorming`-style commands and routes to canonical `/superpowers:*` |
+| superpowers-redirect | `/superpowers-redirect` | Catches legacy `/brainstorming`-style commands and routes to canonical `/superpowers:*` |
 
-Reference content for the larger skills lives in `skills/references/` (progressive
-disclosure — Claude reads these on demand, not on every session start).
+**Upstream Superpowers skills** are under the `/superpowers:*` namespace after installing
+the plugin. Heavy reference content for native skills lives in `skills/references/`
+(progressive disclosure — loaded on demand).
 
-The deterministic pre-commit checks (secret scan, debug-statement scan, large-file warning,
-linter) now run automatically via `.claude/hooks/pre-commit-check.sh` — no skill invocation
-needed before `git commit`.
+**Specialized agents** in `.claude/agents/`: `code-reviewer`, `security-auditor`,
+`doc-writer`, `team-coordinator`.
 
-## Agents Available
+Invocation rules and the brainstorming-gate enforcement detail:
+[`rules/40-skills.md`](./rules/40-skills.md).
 
-Specialized agents are defined in `.claude/agents/`:
-- `code-reviewer` — strict code review with project memory
-- `security-auditor` — OWASP-based vulnerability scanning
-- `doc-writer` — documentation generation with user memory
-- `team-coordinator` — orchestrates agent teams with task dependencies
+## Rules Index
+
+The full rule corpus lives in [`./rules/`](./rules/00-index.md):
+
+| File | Scope |
+|------|-------|
+| [`rules/00-index.md`](./rules/00-index.md) | Load order, conventions, related references. |
+| [`rules/10-iron-laws.md`](./rules/10-iron-laws.md) | Iron laws, narrow exceptions, Absolute Rules register, test discipline, reviewer-verification rule. |
+| [`rules/20-workflow.md`](./rules/20-workflow.md) | Session start, unified pipeline, alternate entry points, escalation, session state handoff. |
+| [`rules/30-git-github-ci.md`](./rules/30-git-github-ci.md) | Branch / PR / commit / CI policy. |
+| [`rules/40-skills.md`](./rules/40-skills.md) | Skill catalogue, invocation rules, progressive disclosure. |
+| [`rules/50-tools.md`](./rules/50-tools.md) | Tool patterns and coding conventions. |
+| [`rules/60-security-privacy.md`](./rules/60-security-privacy.md) | Secrets, destructive commands, audit logging. |
+| [`rules/90-maintenance.md`](./rules/90-maintenance.md) | How to add, retire, or fix a rule. |
+
+## Verification Commands
+
+Run from the repository root:
+
+- `bash scripts/verify.sh` — installation-readiness (tools, env, hooks, skills, agents, gh
+  auth). Set `VERIFY_STRICT_EXAMPLES=1` to treat the seeded todo-app bugs as hard failures.
+- `bash scripts/verify-ci.sh` — local mirror of the CI gating jobs with pinned tool
+  versions. Honestly reports SKIPPED checks when local tooling is missing.
+- `bash scripts/validate-skills.sh` — skill + agent frontmatter validation. `--strict`
+  (or `CMP_STRICT_TOOLS=1`) escalates unknown-tool warnings to failures.
+- `bash scripts/test-hooks.sh` — hook self-test harness with a working-tree mutation guard.
+
+## Maintenance Notes
+
+- Edit rules in [`./rules/`](./rules/00-index.md), not in this file. When this entrypoint and
+  a rule file disagree, the rule file wins — fix the entrypoint the next time you touch it.
+- To add a rule, follow [`rules/90-maintenance.md`](./rules/90-maintenance.md): add it to
+  the most-specific file, and only register a one-line pointer in
+  [`rules/10-iron-laws.md`](./rules/10-iron-laws.md) if it is project-wide non-negotiable.
+- `CLAUDE.md` stays under 200 lines and remains useful on its own; it never carries the
+  full rule corpus.
 
 ## Documentation References
 

--- a/CLAUDE_MD_REFACTOR_REPORT.md
+++ b/CLAUDE_MD_REFACTOR_REPORT.md
@@ -1,0 +1,135 @@
+# CLAUDE.md Refactor Report
+
+Restructured `CLAUDE.md` to the requested section layout (Project Purpose → Operating
+Principles → Non-Negotiable Rules → Workflow → GitHub/CI/Merge Discipline → Skills and Slash
+Commands → Rules Index → Verification Commands → Maintenance Notes). The file stays under
+the 200-line budget, every durable rule is preserved (mostly by reference into
+[`./rules/`](./rules/00-index.md)), and no surrounding code was modified.
+
+## What Changed
+
+- Top-level sections now match the requested taxonomy and order. Old headings (`Project
+  Identity`, `Rules`, `At a Glance`, `Skills Available`, `Agents Available`,
+  `Documentation References`) replaced/renamed/folded:
+  - `Project Identity` → `Project Purpose` (tightened wording; same content; added a
+    pointer to `docs/superpowers-integration.md`).
+  - `At a Glance` + `Rules` (table) → split into `Operating Principles`,
+    `Non-Negotiable Rules`, `Rules Index`.
+  - `Skills Available` + `Agents Available` → consolidated into `Skills and Slash
+    Commands` (single section).
+  - `Documentation References` retained verbatim at the bottom.
+- Added two new sections that did not exist before:
+  - **Workflow** — the unified pipeline diagram + the shortcuts table, both in the same
+    place. Previously the diagram was implicit (only in `rules/20-workflow.md`).
+  - **GitHub / CI / Merge Discipline** — a single section that pulls the branch policy,
+    commit policy, branch-finish policy, and CI gating/non-gating jobs together at
+    summary level. Full table still lives in `rules/30-git-github-ci.md`.
+  - **Verification Commands** — names the four supported repo scripts in one place
+    (`verify.sh`, `verify-ci.sh`, `validate-skills.sh`, `test-hooks.sh`). Previously a
+    reader had to dig into `rules/30-git-github-ci.md` or `rules/90-maintenance.md`.
+  - **Maintenance Notes** — three-line policy: edit rules in `./rules/`, follow
+    `rules/90-maintenance.md` to add a rule, keep this entrypoint under 200 lines.
+- Added one **Operating Principle** that captures rule precedence explicitly (more-specific
+  rule file wins; iron laws win over topic rules; in-conversation user instructions win
+  over CLAUDE.md). This consolidates two pieces of prose previously scattered across
+  `rules/00-index.md` and `rules/90-maintenance.md` — not new policy.
+
+## What Was Preserved
+
+Every durable rule, safety gate, skill reference, branch/PR/CI rule, and privacy/security
+rule from the prior `CLAUDE.md` (and from `rules/`) is still present, either inline at
+summary level or via an explicit link. Checklist:
+
+| Item | Where in new CLAUDE.md |
+|---|---|
+| Project description + two modes (new-project / existing-project) | `Project Purpose` |
+| `.estado.md` session restore + `.env` warning + area detection | `Operating Principles` |
+| Default-to-pipeline rule for ambiguous new work | `Operating Principles` |
+| Preferred tool patterns (Glob/Grep/Read/Edit/Write/Bash) | `Operating Principles` |
+| Coding conventions (shell `set -euo pipefail`, PEP 8, Markdown ATX/100-char/fenced) | `Operating Principles` |
+| Four Iron Laws (TDD, spec gate, root cause, no merge on red) | `Non-Negotiable Rules` |
+| Iron Law enforcement mechanism per law (skill names) | `Non-Negotiable Rules` |
+| "Never" rules: `rm -rf /`, `.env`/secrets, push to `main`/`master`, skip tests, mock fs/db | `Non-Negotiable Rules` |
+| Reviewer-output-is-a-hypothesis rule | `Non-Negotiable Rules` (last paragraph) |
+| Full unified-pipeline diagram | `Workflow` |
+| Superpowers plugin install command | `Workflow` |
+| Shortcuts table (7 entries: fix-issue, review-pr, refactor-module, brainstorm+plans, assemble-team, gen-commit-message, max-power) | `Workflow` |
+| Branch policy + force-push backstop hook | `GitHub / CI / Merge Discipline` |
+| Conventional Commits format | `GitHub / CI / Merge Discipline` |
+| Pre-commit hook (`pre-commit-check.sh`) vs `/gen-commit-message` split | `GitHub / CI / Merge Discipline` |
+| Branch-finish rule + Iron Law #4 reference | `GitHub / CI / Merge Discipline` |
+| CI gating jobs list (shellcheck, actionlint, jq, secrets, structure, smoke) | `GitHub / CI / Merge Discipline` |
+| CI non-gating jobs (markdownlint, todo-app pytest) | `GitHub / CI / Merge Discipline` |
+| Native skills table (all 8) | `Skills and Slash Commands` |
+| Superpowers `/superpowers:*` namespace | `Skills and Slash Commands` |
+| `skills/references/` progressive disclosure | `Skills and Slash Commands` |
+| Specialized agents (code-reviewer, security-auditor, doc-writer, team-coordinator) | `Skills and Slash Commands` |
+| Full rules directory table (all 8 files) | `Rules Index` |
+| Documentation references (the seven `@docs/...` + `@ATTRIBUTION.md`) | `Documentation References` |
+| Subfolder CLAUDE.md override precedence | Header note at top |
+
+## What Was Deduped
+
+- **Rules table appeared twice** in the prior CLAUDE.md — once under `Rules` (header
+  table) and partially again as the `At a Glance` bullets. Now there is one canonical
+  table under `Rules Index`, plus pointed references from each substantive section.
+- **Pipeline + entry points + iron-laws** were each restated in two places (the prose
+  bullet list and the implicit narrative). Now stated once each — iron laws in
+  `Non-Negotiable Rules`, pipeline in `Workflow`, shortcuts in `Workflow`.
+- **Tool patterns and conventions** appeared as two adjacent sections (`Core Coding
+  Conventions` + `Preferred Tool Patterns`). Collapsed into a single five-bullet
+  `Operating Principles` block, with the full convention list still living in
+  `rules/50-tools.md`.
+- **Skills and Agents** were two parallel sections that both deferred to `rules/40-skills.md`
+  anyway. Consolidated.
+
+No durable rule was reworded, weakened, or removed.
+
+## Whether `./rules/` Exists
+
+`./rules/` **exists** in this branch (created earlier on
+`chore/extract-rules-from-claude-md` and carried forward into `chore/refine-claude-md`).
+Eight files:
+
+```
+rules/00-index.md
+rules/10-iron-laws.md
+rules/20-workflow.md
+rules/30-git-github-ci.md
+rules/40-skills.md
+rules/50-tools.md
+rules/60-security-privacy.md
+rules/90-maintenance.md
+```
+
+`CLAUDE.md` accordingly acts as the short entrypoint and links into each rule file. No
+"Future rules extraction" note was needed.
+
+## Final CLAUDE.md Line Count
+
+**194 lines.** Budget: under 200. Headroom: 6 lines.
+
+## Verification
+
+Commands run, in order:
+
+1. `git checkout -b chore/refine-claude-md` → branch created.
+2. `wc -l CLAUDE.md` → **194**.
+3. `grep -n "rules/" CLAUDE.md` → 24 matches (the entrypoint links into rules from every
+   major section).
+4. `grep -n "skills" CLAUDE.md` → 11 matches.
+5. `git diff --stat CLAUDE.md` → `1 file changed, 159 insertions(+), 96 deletions(-)`.
+6. `bash scripts/verify-ci.sh` → **All 11 gating checks passed**, 2 non-gating INFO
+   signals unchanged from main (pre-existing markdown warnings; the three pedagogical
+   todo-app bug fixtures). No regression introduced.
+
+The diff is documentation-only. No skills, scripts, workflows, package files, or unrelated
+docs were modified.
+
+## Stop Conditions Met
+
+- `CLAUDE.md` updated to the requested section structure.
+- `CLAUDE.md` is 194 lines (< 200).
+- Every durable rule preserved — see the "What Was Preserved" checklist above.
+- `CLAUDE_MD_REFACTOR_REPORT.md` exists and is non-empty (this file).
+- `git diff` shows only intentional documentation changes.

--- a/RULES_MIGRATION_REPORT.md
+++ b/RULES_MIGRATION_REPORT.md
@@ -1,0 +1,127 @@
+# Rules Migration Report
+
+Extracted the durable rule corpus from the monolithic root `CLAUDE.md` into a first-class
+`./rules/` directory. `CLAUDE.md` is now a short entrypoint that links into it. No rule was
+deleted or weakened.
+
+## Files Created
+
+| File | Purpose |
+|---|---|
+| `rules/00-index.md` | Overview, load order, file scope table, conventions. |
+| `rules/10-iron-laws.md` | The Four Iron Laws (TDD, spec gate, root cause, no merge on red), narrow exceptions, the **Absolute Rules Register** (single source of truth that cross-references the rest), test-discipline rules, and the "verifying subagent reviews" iron-law variant. |
+| `rules/20-workflow.md` | Session start protocol, the unified Superpowers + ClaudeMaxPower pipeline (ASCII diagram), alternate entry points, "when to use which execution mode", escalation paths, session state handoff (`.estado.md` + Claude Code auto-memory). |
+| `rules/30-git-github-ci.md` | Branch policy (no direct push to `main`/`master`), commit-message format (Conventional Commits), branch-finishing skill, CI expectations with pinned tool versions, mirror-drift clarification between `ci.yml` and `verify-ci.sh`. |
+| `rules/40-skills.md` | Native ClaudeMaxPower skills table (all 8), Superpowers methodology skills, progressive-disclosure rule (`skills/references/`), skill frontmatter validation, agents inventory, invocation discipline (pre-commit hook vs `/gen-commit-message`, `/assemble-team` gate). |
+| `rules/50-tools.md` | Preferred tool patterns (Glob/Grep/Read/Edit/Write/Bash) and core coding conventions per language (Shell, Python, Markdown). |
+| `rules/60-security-privacy.md` | Destructive-command policy, secret handling, hook + CI enforcement layers, audit logging, pointer to test-isolation rule in iron-laws. |
+| `rules/90-maintenance.md` | Adding a new rule, retiring a rule, avoiding duplication, resolving contradictions, validating the directory, what to do when `CLAUDE.md` and `rules/` disagree. |
+
+## Sections Moved from CLAUDE.md
+
+The old `CLAUDE.md` had nine substantive sections (after "Project Identity"). Mapping:
+
+| Old CLAUDE.md section | New location |
+|---|---|
+| Session Start Protocol | `rules/20-workflow.md` § Session Start Protocol |
+| The Unified Pipeline (Superpowers + ClaudeMaxPower) | `rules/20-workflow.md` § The Unified Pipeline + § Alternate Entry Points |
+| The Four Iron Laws | `rules/10-iron-laws.md` § The Four Iron Laws |
+| Core Coding Conventions | `rules/50-tools.md` § Core Coding Conventions |
+| Absolute Rules (Never Break These) — `rm -rf /` line | `rules/60-security-privacy.md` § Destructive Commands (with one-line entry in iron-laws Register) |
+| Absolute Rules — `.env` / secrets line | `rules/60-security-privacy.md` § Secret Handling (with one-line entry in iron-laws Register) |
+| Absolute Rules — no push to `main`/`master` line | `rules/30-git-github-ci.md` § Branch Policy (with one-line entry in iron-laws Register) |
+| Absolute Rules — never skip tests line | `rules/10-iron-laws.md` § Test Discipline (referenced from iron-laws Register) |
+| Absolute Rules — no mock fs/db line | `rules/10-iron-laws.md` § Test Discipline (referenced from iron-laws Register) |
+| Preferred Tool Patterns | `rules/50-tools.md` § Preferred Tool Patterns |
+| Skills Available | Retained as a summary in `CLAUDE.md`; full invocation rules in `rules/40-skills.md` |
+| Agents Available | Retained as a summary in `CLAUDE.md`; also listed in `rules/40-skills.md` |
+| Documentation References | Retained verbatim in `CLAUDE.md` |
+
+Content additionally folded in from `docs/superpowers-integration.md` (already in the
+project, referenced by `CLAUDE.md`) to enrich the rule files without inventing new policy:
+
+- "When to Use Which Execution Mode" table → `rules/20-workflow.md`.
+- "Escalation paths" → `rules/20-workflow.md`.
+- Iron-law exceptions and the "verifying subagent reviews" guidance → `rules/10-iron-laws.md`.
+- Session state handoff (`.estado.md` + Claude Code auto-memory) → `rules/20-workflow.md`.
+
+These were already authoritative for the project; relocating their headline rules into
+`rules/` makes them discoverable as rules rather than as integration prose. The full prose
+remains in `docs/superpowers-integration.md`.
+
+## Rules Deduped
+
+The five lines of the old "Absolute Rules (Never Break These)" section overlapped with
+several topic-specific concerns. To honour the "rule stated once" constraint:
+
+- Each absolute rule is stated **once** in its most-specific topic file (security, git/CI,
+  or test discipline).
+- `rules/10-iron-laws.md` contains an **Absolute Rules Register** — a one-line-each table
+  that links to the owning file. This is the explicit exception to the "no duplication"
+  rule, justified in `rules/90-maintenance.md`: it lets a reader see the complete inventory
+  of non-negotiables without opening every file.
+
+Other overlapping content (the unified-pipeline diagram, the iron-laws prose) appeared in
+both old `CLAUDE.md` and `docs/superpowers-integration.md`. The new rule files become the
+canonical reference; `docs/superpowers-integration.md` remains the integration design
+narrative. They are no longer duplicates in the rule-corpus sense, just complementary views.
+
+## Ambiguities Found
+
+Two items required interpretation; both are marked as **clarification** in the rule files.
+
+1. **Two "Absolute Rules" cross-cut topics.** "Never skip tests when they exist" and "never
+   mock the filesystem or database when real implementations are available" are absolute
+   *and* test-specific. The user's suggested structure had no test-rules file. Resolution:
+   placed them in `rules/10-iron-laws.md` under "Test Discipline" because they share
+   epistemic ground with Iron Law #1 (TDD), and registered them in the Absolute Rules
+   Register. No new policy.
+2. **`scripts/verify-ci.sh` REQUIRED list and `.github/workflows/ci.yml` `check-structure`
+   REQUIRED list are duplicated.** This is an existing project fact (`verify-ci.sh` even
+   warns about it in a comment block). Surfaced as a "clarification" in
+   `rules/30-git-github-ci.md` so future readers know mirrors must move together.
+
+No durable rule was reinterpreted, weakened, or invented.
+
+## Verification
+
+Commands run, in order:
+
+1. `git checkout -b chore/extract-rules-from-claude-md` — branch created.
+2. `bash scripts/verify-ci.sh` — mirrors the CI gating jobs locally with pinned tool
+   versions (shellcheck v0.10.0, actionlint 1.7.7).
+   - Result: **All 11 gating checks passed**. Two non-gating INFO lines (markdown warnings
+     pre-existing; todo-app pedagogical bug fixtures) — unchanged from a clean main.
+3. `bash scripts/validate-skills.sh` — skill + agent frontmatter validation.
+   - Result: **All 12 entries PASS** (8 skills + 4 agents). No skills modified.
+4. `bash scripts/test-hooks.sh` — hook self-test harness.
+   - Result: **All 21 hook self-tests passed**, including the working-tree mutation guard
+     ("repo working tree unchanged").
+5. Relative-link spot check for every `../` link in `rules/*.md`:
+
+   ```
+   for f in CLAUDE.md docs/hooks-guide.md docs/skills-guide.md docs/agents-guide.md \
+            docs/agent-teams-guide.md docs/batch-workflows.md docs/superpowers-integration.md \
+            ATTRIBUTION.md; do
+     [ -f "$f" ] && echo "OK: $f" || echo "MISSING: $f"
+   done
+   ```
+
+   Result: **all 8 link targets resolve**.
+
+6. `git status --short` after edits — only `CLAUDE.md` modified plus new `rules/` and the new
+   `RULES_MIGRATION_REPORT.md`. The pre-existing untracked files
+   (`.claude/scheduled_tasks.lock`, `AUDIT_REPORT.md`) are unrelated and unchanged.
+
+## Stop Conditions Met
+
+- `./rules/` exists with 8 markdown files (`00-index.md`, `10-iron-laws.md`, `20-workflow.md`,
+  `30-git-github-ci.md`, `40-skills.md`, `50-tools.md`, `60-security-privacy.md`,
+  `90-maintenance.md`).
+- `CLAUDE.md` updated as a concise index that links to `./rules/00-index.md` and to each
+  individual rule file. Skill catalogue and Documentation References preserved verbatim.
+- `RULES_MIGRATION_REPORT.md` exists and is non-empty (this file).
+- Validation has been run — see "Verification" section above.
+- `git diff` shows only the intended rule-organization changes (`CLAUDE.md` rewrite, new
+  `rules/` directory, this report). No skill files were touched. No unrelated files were
+  touched.

--- a/rules/00-index.md
+++ b/rules/00-index.md
@@ -1,0 +1,43 @@
+# ClaudeMaxPower — Rules Index
+
+This directory holds the durable rules for the ClaudeMaxPower repository. `CLAUDE.md` at the
+repository root is a short entrypoint that links here; the full rule corpus lives in this
+directory.
+
+> Rules in this directory take precedence over generic Claude defaults. Subfolder `CLAUDE.md`
+> files extend or override rules for their specific context.
+
+## Load Order and Purpose
+
+Files are numbered so a human (or a tooling pipeline) can read them top-to-bottom and reach a
+self-consistent understanding of how this project is governed.
+
+| File | Scope |
+|------|-------|
+| [10-iron-laws.md](10-iron-laws.md) | Non-negotiable project laws — TDD, spec gate, root cause, no merge on red, plus the "Absolute Rules" register that cross-references the rest. |
+| [20-workflow.md](20-workflow.md) | Session start protocol, the unified Superpowers + ClaudeMaxPower pipeline, alternate entry points, escalation paths. |
+| [30-git-github-ci.md](30-git-github-ci.md) | Branch policy, PR policy, commit-message format, CI expectations, GitHub Actions rules. |
+| [40-skills.md](40-skills.md) | Native ClaudeMaxPower skills, Superpowers skills, skill invocation rules, progressive disclosure. |
+| [50-tools.md](50-tools.md) | Preferred tool patterns (Glob/Grep/Read/Edit/Write/Bash) and core coding conventions per language. |
+| [60-security-privacy.md](60-security-privacy.md) | Secret handling, `.env` policy, destructive-command policy, test-isolation policy. |
+| [90-maintenance.md](90-maintenance.md) | Rule hygiene, audit/cleanup conventions, how to add or retire a rule. |
+
+## Conventions
+
+- Each rule file uses ATX headings (`#`).
+- A rule is stated once in the most specific file. Broader files reference it rather than
+  repeat it.
+- Anything marked **clarification** is a disambiguation added during the extraction from the
+  former monolithic `CLAUDE.md`; it does not introduce new policy.
+- When two files appear to disagree, the more specific file wins. If you find an actual
+  contradiction, treat it as a bug — see [90-maintenance.md](90-maintenance.md).
+
+## Related References
+
+- [`../CLAUDE.md`](../CLAUDE.md) — short entrypoint and summary.
+- [`../docs/superpowers-integration.md`](../docs/superpowers-integration.md) — how the upstream
+  Superpowers methodology integrates with ClaudeMaxPower infrastructure.
+- [`../docs/hooks-guide.md`](../docs/hooks-guide.md), [`../docs/skills-guide.md`](../docs/skills-guide.md),
+  [`../docs/agents-guide.md`](../docs/agents-guide.md), [`../docs/agent-teams-guide.md`](../docs/agent-teams-guide.md),
+  [`../docs/batch-workflows.md`](../docs/batch-workflows.md) — operational guides referenced by the rules.
+- [`../ATTRIBUTION.md`](../ATTRIBUTION.md) — third-party content licensing.

--- a/rules/10-iron-laws.md
+++ b/rules/10-iron-laws.md
@@ -1,0 +1,92 @@
+# 10 — Iron Laws
+
+Non-negotiable rules. The Four Iron Laws are the foundation of the unified pipeline; the
+"Absolute Rules" register below cross-references the other policies that are equally
+non-negotiable but live in topic-specific files.
+
+## The Four Iron Laws
+
+These are enforced by the skills and hooks documented in [20-workflow.md](20-workflow.md) and
+[40-skills.md](40-skills.md) and must be respected in every session.
+
+1. **No production code without a failing test first** — enforced by
+   `/superpowers:test-driven-development`. A test must be written, observed to fail for the
+   right reason, and only then is implementation code allowed. The "for the right reason"
+   clause matters: a test that fails because of a typo is not a red test.
+2. **No implementation without an approved spec** — enforced by the
+   `/superpowers:brainstorming` hard gate. Non-trivial work requires a spec that names the
+   problem, the chosen approach, and the success criteria. Trivial work (one-line fixes,
+   typos) is exempt.
+3. **No fixes without root cause investigation** — enforced by
+   `/superpowers:systematic-debugging` Phase 1. Symptoms are not causes. A fix that makes
+   the symptom go away without explaining why the symptom appeared is provisional at best.
+4. **No merging with failing tests** — enforced by
+   `/superpowers:finishing-a-development-branch` Step 1 (verify). The test suite runs green
+   before merge, PR, or any branch-finalizing action.
+
+The laws are cumulative. A change that passes tests (law 4) but skipped the spec (law 2) is
+still a violation. A change with a spec and passing tests but no root-cause analysis (law 3)
+is still a violation when it touches bug territory.
+
+### Narrow Exceptions
+
+Each law has a narrow exception that exists so the methodology does not become theater. Using
+an exception routinely is a signal that the shape of the work has shifted and the pipeline
+should be reconsidered.
+
+- **Law 1 exception** — Exploratory spikes that will be deleted before merging. Use a scratch
+  branch with informal testing. The moment the spike becomes real code, the law applies
+  retroactively — tests come before further production code.
+- **Law 2 exception** — Trivial changes (typos, obvious one-liners, formatting) do not need a
+  spec. A change is "trivial" when a reviewer would not ask "why?" about it.
+- **Law 3 exception** — Known flakes with documented workarounds can be patched without deep
+  root-cause investigation if the patch itself is well-isolated. The underlying cause stays
+  on the backlog.
+- **Law 4 exception** — None. Failing tests block the merge. If a test is known-broken and
+  unrelated, it must be marked as skipped with a tracking issue, not ignored.
+
+## Absolute Rules Register
+
+These are the project-wide "never do" rules. Each is owned by a topic-specific file; this
+register exists so a reader who only opens one rule file still sees the complete inventory.
+
+| Rule | Owning file |
+|------|-------------|
+| Never run `rm -rf /` or any destructive command without explicit user confirmation. | [60-security-privacy.md](60-security-privacy.md) |
+| Never commit `.env` or any file containing real secrets or tokens. | [60-security-privacy.md](60-security-privacy.md) |
+| Never push to `main` or `master` directly. Always use a feature branch + PR. | [30-git-github-ci.md](30-git-github-ci.md) |
+| Never skip tests when they exist. If tests fail, fix the code, not the tests. | This file — see "Test Discipline" below |
+| Never mock the filesystem or database in tests when real implementations are available. | This file — see "Test Discipline" below |
+
+## Test Discipline
+
+The two test-related "never" rules live here because they belong with the TDD iron law:
+
+- **Never skip tests when they exist.** If tests fail, fix the code, not the tests. Marking a
+  test skipped is permitted only under Law 4's narrow exception (known-broken, unrelated, with
+  a tracking issue).
+- **Never mock the filesystem or database in tests when real implementations are available.**
+  Tests that mock components that could be real are a smell — they pass even when the real
+  contract is broken. Use temporary directories for filesystem tests and a real (test-scoped)
+  database when one is available.
+
+## Verifying Subagent Reviews
+
+`/superpowers:subagent-driven-development` and `Agent(subagent_type=code-reviewer)` produce
+structured review output that looks authoritative. Treat reviewer output as a high-signal
+*hypothesis*, not a verdict. Verify each claim against the code before applying it.
+
+This is an iron-law variant of Law 3 (no fixes without root-cause investigation) applied to
+the case where the "report" comes from another LLM session rather than a human bug report.
+
+- **Read the cited line.** A claim like "off-by-one in the truncation loop" only matters if
+  the loop actually has the off-by-one. Open the file at the cited line and decide for
+  yourself.
+- **Reproduce the alleged failure with a test.** If the reviewer says behaviour X is wrong for
+  input Y, write the test that asserts the correct behaviour. If the test passes, the claim
+  was wrong; if it fails, the fix is grounded.
+- **Distinguish style notes from correctness claims.** Style and naming critiques are usually
+  safe to apply on judgment alone. Correctness, performance, and security claims need
+  empirical confirmation.
+- **Resist the "it's-the-reviewer-so-it-must-be-right" reflex.** The whole point of two-stage
+  review is to surface signal — not to bypass your own judgment.

--- a/rules/20-workflow.md
+++ b/rules/20-workflow.md
@@ -1,0 +1,108 @@
+# 20 — Workflow
+
+Session start protocol, the unified pipeline, and the alternate entry points used when the
+full pipeline would add more friction than value.
+
+## Session Start Protocol
+
+At the start of every session:
+
+1. Check if `.estado.md` exists in the project root. If it does, read it to restore context.
+   (`.estado.md` is written by the `stop` hook and surfaced by the `session-start` hook —
+   see [`../docs/hooks-guide.md`](../docs/hooks-guide.md).)
+2. Check if `.env` exists. If it does not, warn the user and suggest running
+   `bash scripts/setup.sh`.
+3. Identify which area of the project you are working in (hooks / skills / agents / examples
+   / docs).
+4. If the user's goal is ambiguous and involves any new feature, default to the pipeline:
+   **brainstorm → spec → plan → execute → review → finish**.
+
+## The Unified Pipeline (Superpowers + ClaudeMaxPower)
+
+The methodology skills (brainstorming, plans, TDD, debugging, worktrees, finish) live
+upstream in the Superpowers plugin. Install with:
+
+```
+/plugin install superpowers@claude-plugins-official
+```
+
+Invoke them with the `/superpowers:*` namespace. ClaudeMaxPower keeps a thin
+`/superpowers-redirect` skill that catches the old slash commands and points users to the
+canonical replacements — see [40-skills.md](40-skills.md).
+
+```
+Idea
+ ├─ /superpowers:brainstorming                      → docs/specs/YYYY-MM-DD-<topic>-design.md (hard gate)
+ ├─ /superpowers:writing-plans                      → docs/plans/YYYY-MM-DD-<topic>-plan.md
+ ├─ /superpowers:using-git-worktrees                → isolated branch workspace
+ ├─ /superpowers:subagent-driven-development        → fresh subagent per task + two-stage review
+ │    └─ /superpowers:test-driven-development           (strict Red-Green-Refactor, iron law)
+ │    └─ /superpowers:systematic-debugging              (root cause before fix)
+ └─ /superpowers:finishing-a-development-branch     → merge / PR / keep / discard + worktree cleanup
+```
+
+Each iron law in [10-iron-laws.md](10-iron-laws.md) is enforced at a specific step of the
+pipeline.
+
+## Alternate Entry Points
+
+When the full pipeline would add more friction than value, use one of the native
+ClaudeMaxPower skills:
+
+| Situation | Entry point |
+|---|---|
+| Existing GitHub issue | `/fix-issue` (escalates to `/superpowers:systematic-debugging` if stuck) |
+| Structured PR review | `/review-pr` |
+| Architectural refactor | `/superpowers:brainstorming` + `/superpowers:writing-plans` |
+| Simple refactor | `/refactor-module` |
+| Team pattern for large features | `/assemble-team` (enforces brainstorming gate in new-project mode) |
+| Conventional Commits message | `/gen-commit-message` (the deterministic pre-commit checks now run automatically via `.claude/hooks/pre-commit-check.sh`) |
+| One-command bootstrap | `/max-power` (installs, configures, presents menu) |
+
+The full skill catalogue and invocation rules live in [40-skills.md](40-skills.md).
+
+## When to Use Which Execution Mode
+
+| Situation                                          | Recommended path                                                     |
+|----------------------------------------------------|----------------------------------------------------------------------|
+| Greenfield feature, uncertain requirements         | `/superpowers:brainstorming` then `/superpowers:writing-plans` then `/superpowers:subagent-driven-development` |
+| Greenfield feature, clear spec, want team pattern  | `/superpowers:brainstorming` then `/assemble-team`                   |
+| Existing bug in a tracked issue                    | `/fix-issue` (escalate to `/superpowers:systematic-debugging` if stuck) |
+| Existing unclear bug                               | `/superpowers:systematic-debugging` then `/superpowers:test-driven-development` for the regression test |
+| Refactor an existing module                        | `/refactor-module` for simple cases; `/superpowers:brainstorming` + `/superpowers:writing-plans` for architectural ones |
+| Mass changes across many files                     | `workflows/mass-refactor.sh`                                         |
+| Parallel independent fixes                         | `workflows/batch-fix.sh`                                             |
+
+The default path for new work is the full pipeline. Shortcuts exist for situations where
+the ceremony would add more friction than value — a typo fix does not need a brainstorming
+session.
+
+## Escalation Paths
+
+Work often starts on a short path and escalates when it turns out to be harder than it
+looked. Escalation is not failure — it is a signal that early estimates of the work's shape
+were optimistic.
+
+- **`/fix-issue` → `/superpowers:systematic-debugging`.** When a tracked issue's described
+  symptom does not match any obvious cause in the code, abandon the quick-fix attempt and
+  switch to the 4-phase root cause investigation.
+- **`/refactor-module` → `/superpowers:brainstorming` + `/superpowers:writing-plans`.** When
+  the refactor goal turns out to require cross-module changes or affects public contracts,
+  stop and plan the work before continuing.
+- **`/superpowers:subagent-driven-development` → `/assemble-team`.** When a planned task
+  turns out to span multiple disciplines (backend + frontend + docs), switch from sequential
+  subagents to a parallel team.
+- **Exploratory spike → `/superpowers:test-driven-development`.** When a quick prototype
+  graduates to real code, switch to the strict TDD loop and retrofit any untested behavior.
+
+## Session State Handoff
+
+Across sessions, ClaudeMaxPower preserves state through two mechanisms:
+
+- **`.estado.md`** is written by the `stop` hook at the end of each session and read by the
+  `session-start` hook at the beginning of the next one. The session-start hook surfaces
+  only the three most recent entries to keep the loaded context small; older entries remain
+  in the file for reference.
+- **Claude Code's own auto-memory** (under the user-level memory directory) is the canonical
+  store for user, feedback, project, and reference memories. ClaudeMaxPower does not maintain
+  a separate memory store and does not run any background consolidation process.

--- a/rules/30-git-github-ci.md
+++ b/rules/30-git-github-ci.md
@@ -1,0 +1,58 @@
+# 30 — Git, GitHub, and CI
+
+Branch policy, PR policy, commit message format, and CI expectations. Test-discipline rules
+that touch git workflow are owned by [10-iron-laws.md](10-iron-laws.md); secret hygiene at
+commit time is owned by [60-security-privacy.md](60-security-privacy.md).
+
+## Branch Policy
+
+- **Never push to `main` or `master` directly.** Always use a feature branch + PR. This is
+  one of the Absolute Rules registered in [10-iron-laws.md](10-iron-laws.md).
+- The hook `.claude/hooks/pre-tool-use.sh` blocks force-pushes to `main` or `master` as a
+  backstop — see [`../docs/hooks-guide.md`](../docs/hooks-guide.md).
+
+## Commit Messages
+
+- Use **Conventional Commits** format: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`,
+  `test:`.
+- Subject lines stay short; details go in the body.
+- The deterministic pre-commit checks (secret scan, debug-statement scan, large-file warning,
+  linter pass) run automatically via `.claude/hooks/pre-commit-check.sh` — no skill
+  invocation needed before `git commit`.
+- The LLM-judgment portion of the old `/pre-commit` skill (proposing the message itself)
+  lives in `/gen-commit-message` — see [40-skills.md](40-skills.md).
+
+## Branch Finishing
+
+- Use `/superpowers:finishing-a-development-branch` to decide what happens at the end of a
+  branch: merge, open a PR, keep open, or discard.
+- The skill verifies tests pass before any branch-finalizing action — see iron law #4 in
+  [10-iron-laws.md](10-iron-laws.md).
+
+## CI Expectations
+
+CI is defined in `.github/workflows/ci.yml`. The gating jobs are:
+
+| Job | Tool / pinned version | Notes |
+|---|---|---|
+| Validate Shell Scripts | shellcheck `v0.10.0` | Lints `.claude/hooks/*.sh`, `workflows/*.sh`, `scripts/*.sh`. |
+| Validate GitHub Actions Workflows | actionlint `1.7.7` | Lints workflow YAML. |
+| Validate JSON Files | `jq empty` | Validates `.claude/settings.json`, `mcp/*.json`. |
+| Check for Secrets | `grep` | Blocks real-looking `ghp_*` / `sntrys_*` tokens in tracked files. See [60-security-privacy.md](60-security-privacy.md). |
+| Verify Project Structure | `test -f` loop | Mirrored in `scripts/verify-ci.sh`. |
+| Cross-Platform Smoke | `scripts/validate-skills.sh`, `scripts/test-hooks.sh` | Runs on Ubuntu, macOS, Windows. |
+
+Non-gating jobs (`continue-on-error: true` or `|| true`):
+
+- **Lint Markdown** — informational.
+- **Run Example Tests** — `examples/todo-app` ships with three intentional bugs as
+  pedagogical fixtures. The run is informational; only `pytest --collect-only` is gating.
+
+Run locally with `bash scripts/verify-ci.sh` for the same checks CI runs, with the same
+pinned tool versions. Run `bash scripts/verify.sh` for the broader installation-readiness
+check (tools, env, hooks, skills, agents, gh auth).
+
+**Clarification:** the required-files manifest is duplicated between
+`.github/workflows/ci.yml` (job `check-structure`) and `scripts/verify-ci.sh`. Any addition
+or removal must be mirrored in both — drift causes the inversion "local says red, CI says
+green" or vice versa.

--- a/rules/40-skills.md
+++ b/rules/40-skills.md
@@ -1,0 +1,85 @@
+# 40 — Skills
+
+Native ClaudeMaxPower skills, Superpowers methodology skills, invocation rules, and
+progressive-disclosure conventions for reference content.
+
+## Native ClaudeMaxPower Skills
+
+The following skills live in `skills/` and are invoked with `/skill-name`. There are eight.
+
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| max-power | `/max-power` | One-command activation — install, configure, route to your goal |
+| assemble-team | `/assemble-team` | Assemble an agent team (enforces brainstorming gate in new-project mode) |
+| fix-issue | `/fix-issue` | Fix a GitHub issue end-to-end |
+| review-pr | `/review-pr` | Full PR review workflow |
+| refactor-module | `/refactor-module` | Safe module refactor with tests |
+| generate-docs | `/generate-docs` | Auto-generate docs from code |
+| gen-commit-message | `/gen-commit-message` | Read staged diff, propose Conventional Commits message |
+| superpowers-redirect | `/superpowers-redirect` | Catches old `/brainstorming`-style commands and routes to canonical `/superpowers:*` |
+
+## Superpowers Methodology Skills
+
+The methodology skills (brainstorming, plans, TDD, debugging, worktrees, finish) live
+upstream in the Superpowers plugin. Install with:
+
+```
+/plugin install superpowers@claude-plugins-official
+```
+
+Invoke them with the `/superpowers:*` namespace. The full pipeline that wires them together
+is documented in [20-workflow.md](20-workflow.md), and the integration design lives in
+[`../docs/superpowers-integration.md`](../docs/superpowers-integration.md).
+
+If a user types a legacy unqualified name (`/brainstorming`, `/tdd-loop`, etc.), the
+`/superpowers-redirect` skill catches it and points to the canonical replacement.
+
+## Progressive Disclosure: `skills/references/`
+
+Heavy reference content — long checklists, role catalogues, install scripts, helper one-liners
+— lives under `skills/references/` instead of being inlined into the skill body. The skill
+points to the reference file when it needs the content; Claude reads it on demand rather than
+on every session start.
+
+When you write a new skill: if the body grows past ~150 lines or contains a long table /
+checklist / template that would be useful to other skills, extract it to
+`skills/references/<topic>.md` and reference it from the skill body.
+
+## Skill Frontmatter Validation
+
+Run `bash scripts/validate-skills.sh` after editing or adding a skill to confirm:
+
+- The YAML frontmatter has the required fields.
+- Every entry in `allowed-tools` is a recognised Claude Code tool.
+
+Unknown tools are warnings by default; `--strict` (or `CMP_STRICT_TOOLS=1`) escalates them to
+failures. The known-tool list lives in `scripts/known-claude-tools.txt` — append to it when
+Claude Code introduces a new tool you want to use.
+
+This script also runs in CI as part of the `Cross-Platform Smoke` job — see
+[30-git-github-ci.md](30-git-github-ci.md).
+
+## Agents
+
+Specialized agents live in `.claude/agents/`:
+
+- `code-reviewer` — strict code review with project memory.
+- `security-auditor` — OWASP-based vulnerability scanning.
+- `doc-writer` — documentation generation with user memory.
+- `team-coordinator` — orchestrates agent teams with task dependencies.
+
+Operational details: [`../docs/agents-guide.md`](../docs/agents-guide.md),
+[`../docs/agent-teams-guide.md`](../docs/agent-teams-guide.md).
+
+## Invocation Discipline
+
+- The deterministic pre-commit checks (secret scan, debug-statement scan, large-file warning,
+  linter) run automatically via `.claude/hooks/pre-commit-check.sh` — no skill invocation is
+  needed before `git commit`. The LLM portion (proposing a Conventional Commits message)
+  lives in `/gen-commit-message`.
+- `/assemble-team --mode new-project` enforces the brainstorming gate: a spec must exist
+  before the team is assembled. If no spec is present, the skill directs the user to
+  `/superpowers:brainstorming` first. `--mode existing-project` does not enforce the gate,
+  because the existing codebase serves as the specification of how things currently behave.
+- Skills should never weaken an iron law from [10-iron-laws.md](10-iron-laws.md). When a
+  skill's workflow appears to short-circuit an iron law, the iron law wins.

--- a/rules/50-tools.md
+++ b/rules/50-tools.md
@@ -1,0 +1,31 @@
+# 50 — Tools and Coding Conventions
+
+Preferred tool patterns for Claude and core coding conventions per language.
+
+## Preferred Tool Patterns
+
+Use the dedicated tool, not the shell command:
+
+- **File search** — `Glob` tool (not `find`)
+- **Content search** — `Grep` tool (not `grep`)
+- **File reads** — `Read` tool (not `cat`)
+- **File edits** — `Edit` for targeted changes, `Write` only for new files or full rewrites
+- **Shell** — `Bash` only for commands that require execution
+
+## Core Coding Conventions
+
+- **Languages** — Shell (bash), Python 3, Markdown. Match the language of the file being
+  modified.
+- **Shell scripts** — Use `set -euo pipefail`. Always quote variables. Use `local` in
+  functions.
+- **Python** — PEP 8. Type hints for public functions. `pytest` for tests. No global state.
+- **Markdown** — ATX headings (`#`). 100-char line limit. Fenced code blocks with language
+  tags.
+- **Commit messages** — Conventional Commits format. See
+  [30-git-github-ci.md](30-git-github-ci.md) for the canonical commit policy.
+
+## Test-Mocking Policy
+
+The "do not mock the filesystem or database when real implementations are available" rule
+lives in [10-iron-laws.md](10-iron-laws.md) under "Test Discipline" — it is an iron law, not
+a coding convention.

--- a/rules/60-security-privacy.md
+++ b/rules/60-security-privacy.md
@@ -1,0 +1,42 @@
+# 60 — Security and Privacy
+
+Secret handling, destructive-command policy, and the safety boundaries between Claude Code
+itself and the ClaudeMaxPower hook backstop.
+
+## Destructive Commands
+
+- **Never run `rm -rf /` or any destructive command without explicit user confirmation.**
+  This is one of the Absolute Rules registered in [10-iron-laws.md](10-iron-laws.md).
+- The hook `.claude/hooks/pre-tool-use.sh` blocks a regex-matched subset of catastrophic
+  patterns (`rm -rf /`, `rm -rf ~`, fork bombs, `dd if=/dev/zero`, `mkfs.`, `DROP TABLE`,
+  `DROP DATABASE`, `TRUNCATE TABLE`, force-push to `main`/`master`). It is defense in depth,
+  not the primary boundary — see "Hooks vs Claude Code's Sandbox" in
+  [`../docs/hooks-guide.md`](../docs/hooks-guide.md).
+- The block-list cannot stop obfuscated commands, dangerous behaviour via non-`Bash` tools,
+  or logic-level harm. Respect Claude Code's permission prompts; prefer plan mode for risky
+  work.
+
+## Secret Handling
+
+- **Never commit `.env` or any file containing real secrets or tokens.** This is one of the
+  Absolute Rules registered in [10-iron-laws.md](10-iron-laws.md).
+- The hook `.claude/hooks/pre-commit-check.sh` inspects `git diff --staged` for likely
+  secrets (api keys, tokens, passwords) and blocks the commit if any are found — see
+  [`../docs/hooks-guide.md`](../docs/hooks-guide.md).
+- The CI job `validate-no-secrets` blocks pushed commits that contain real-looking GitHub
+  (`ghp_*`) or Sentry (`sntrys_*`) tokens anywhere in tracked files, including `.env.example`.
+  See [30-git-github-ci.md](30-git-github-ci.md).
+- `.env` is local-only. If it does not exist, the session-start hook warns the user and
+  suggests `bash scripts/setup.sh`.
+
+## Audit Logging
+
+- Every bash command Claude runs is logged to `.claude/audit.log` by
+  `.claude/hooks/pre-tool-use.sh` with a timestamp.
+- `.claude/audit.log` is in `.gitignore` — it is local only and never pushed.
+
+## Test Isolation
+
+The rule "never mock the filesystem or database in tests when real implementations are
+available" lives in [10-iron-laws.md](10-iron-laws.md) under "Test Discipline". It belongs
+there because a violation also violates the TDD iron law's "for the right reason" clause.

--- a/rules/90-maintenance.md
+++ b/rules/90-maintenance.md
@@ -1,0 +1,67 @@
+# 90 — Maintenance and Rule Hygiene
+
+How to add a new rule, retire an old one, and keep this directory consistent over time.
+
+## Adding a New Rule
+
+1. Decide which existing file owns the topic. The file table in
+   [00-index.md](00-index.md) is the index of scopes.
+2. Add the rule to the most specific file. If the rule is also non-negotiable
+   project-wide, add a one-line entry to the "Absolute Rules Register" in
+   [10-iron-laws.md](10-iron-laws.md) pointing at the owning file — do not repeat the rule
+   text there.
+3. If the rule needs a new scope that no existing file covers, create a new numbered file
+   (gaps in the numbering are fine) and add it to the table in [00-index.md](00-index.md).
+
+## Retiring a Rule
+
+- A rule is "retired" by removing it from its owning file and from any cross-reference in
+  [10-iron-laws.md](10-iron-laws.md) or [00-index.md](00-index.md).
+- Do not leave stub references behind. Either the rule applies or it does not.
+- If a rule was once enforced by a hook, skill, or CI check that has been removed, retire the
+  rule together with the enforcement mechanism — otherwise readers will assume the
+  enforcement still exists.
+
+## Avoiding Duplication
+
+- A rule is stated once. Broader files reference the specific file instead of repeating the
+  rule.
+- The "Absolute Rules Register" in [10-iron-laws.md](10-iron-laws.md) is the one explicit
+  exception: it lists each project-wide non-negotiable as a single-line pointer, so the
+  reader of any one file still gets the full inventory.
+
+## Resolving Apparent Contradictions
+
+If two files appear to contradict each other:
+
+1. The more specific file wins by default.
+2. Open an issue or fix the inconsistency in the same PR that introduced it.
+3. If the contradiction is between an iron law and a topic rule, the iron law wins — that is
+   the whole point of [10-iron-laws.md](10-iron-laws.md).
+
+## Validating This Directory
+
+The repository's existing validation scripts cover the surrounding infrastructure but do not
+validate rule content. The supported validation today is:
+
+- `bash scripts/verify.sh` — installation-readiness check.
+- `bash scripts/verify-ci.sh` — locally mirrors the CI gating jobs.
+- `bash scripts/validate-skills.sh` — skill frontmatter validation.
+- `bash scripts/test-hooks.sh` — hook self-tests.
+
+When editing rule files, manually:
+
+1. Confirm the link to [00-index.md](00-index.md) from [`../CLAUDE.md`](../CLAUDE.md) still
+   resolves.
+2. Confirm every relative link in this directory still resolves.
+3. Confirm no rule appears in two files (search the directory with `Grep` for distinctive
+   phrasing).
+
+## When CLAUDE.md and rules/ Disagree
+
+[`../CLAUDE.md`](../CLAUDE.md) is the entrypoint and should remain useful on its own, but it
+no longer carries the full rule corpus. When the entrypoint and a rule file disagree:
+
+- The rule file wins (more specific).
+- The entrypoint should be updated to summarize the rule file correctly.
+- A discrepancy of this kind is a small bug — fix it the next time you touch either file.


### PR DESCRIPTION
## Summary

Restructures the root `CLAUDE.md` rule corpus into a first-class `./rules/` directory and refines `CLAUDE.md` itself as a concise (194-line) entrypoint that links into it.

- **New `./rules/`** — 8 files (`00-index.md`, `10-iron-laws.md`, `20-workflow.md`, `30-git-github-ci.md`, `40-skills.md`, `50-tools.md`, `60-security-privacy.md`, `90-maintenance.md`) covering iron laws, workflow, git/CI, skills, tools, security/privacy, and rule hygiene.
- **`CLAUDE.md` (194 lines, was 131)** — section taxonomy: Project Purpose → Operating Principles → Non-Negotiable Rules → Workflow → GitHub / CI / Merge Discipline → Skills and Slash Commands → Rules Index → Verification Commands → Maintenance Notes → Documentation References.
- **Two audit reports** at repo root: `RULES_MIGRATION_REPORT.md` and `CLAUDE_MD_REFACTOR_REPORT.md` document the section-to-file mapping, deduplication ledger, and verification.

## Stacked on PR #42

> [!IMPORTANT]
> This branch is currently based on `fix/audit-techniques-md-sweep` (PR #42). Review **after PR #42 merges**, unless GitHub already shows a clean diff against `main`.
>
> Targeting PR #42's branch as the base so the diff here shows **only** the rules-extraction work and not the unrelated audit commits from PR #42. When PR #42 merges, GitHub will auto-retarget this PR to `main`. If it does not show a clean diff at that point, I will rebase `chore/refine-claude-md` onto the latest `main`.

## What was preserved

Every durable rule, safety gate, skill reference, branch/PR/CI rule, and privacy/security rule from the prior `CLAUDE.md` is preserved (inline at summary level or by explicit link). The four Iron Laws, the five "never" rules, the unified-pipeline diagram, the eight-skill catalogue, the four agent names, the Conventional Commits format, the pre-commit hook ↔ `/gen-commit-message` split, the CI gating manifest, the session-start protocol, and the `@docs/*` + `@ATTRIBUTION.md` references are all still present. Full mapping in `CLAUDE_MD_REFACTOR_REPORT.md`.

No rule was reworded, weakened, or removed. The two test-cross-cutting rules ("never skip tests", "never mock fs/db when real available") were placed under Test Discipline in `10-iron-laws.md` because they share epistemic ground with Iron Law #1. The Absolute Rules Register in `10-iron-laws.md` is the one explicit duplication exception, justified in `90-maintenance.md`.

## Out of scope

- No skill files modified.
- No scripts, workflows, or package files modified.
- No unrelated docs modified.

## Test plan

- [x] `bash scripts/verify-ci.sh` → all 11 gating checks passed; 2 non-gating INFO signals unchanged from main (pre-existing markdown warnings, pedagogical todo-app bugs).
- [x] `bash scripts/validate-skills.sh` → all 12 entries (8 skills + 4 agents) pass.
- [x] `bash scripts/test-hooks.sh` → all 21 hook self-tests passed; working-tree mutation guard clean.
- [x] All `../` relative links in `rules/*.md` resolve to existing files.
- [x] `wc -l CLAUDE.md` → 194 (under the 200-line budget).
- [ ] Reviewer: confirm the section-to-file mapping in `RULES_MIGRATION_REPORT.md` and `CLAUDE_MD_REFACTOR_REPORT.md` matches the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)