### PR TITLE
refactor(skills): audit visibility, determinism, and composability

### DIFF
--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -195,11 +195,19 @@ Current reference files:
 | File | Used by |
 |---|---|
 | `skills/references/team-roster.md` | `/assemble-team` Step 3 (role catalogue, composition rules, spawn order, dependencies) |
+| `skills/references/check-spec-gate.sh` | `/assemble-team` Step 0 (brainstorming-gate spec presence check; exits 0 with path of most recent spec, 1 if none) |
 | `skills/references/review-pr-checklist.md` | `/review-pr` Step 3 (Correctness/Security/Tests/Style/Breaking/Operational checklist) |
 | `skills/references/max-power-install-strategies.md` | `/max-power` Step 2 (in-place / subdirectory / tarball-fallback install commands) |
 | `skills/references/max-power-status-dashboard.md` | `/max-power` Step 7 (status block template) |
+| `skills/references/detect-cmp-installation.sh` | `/max-power` Step 1.2 (3-marker CMP-install check; prints yes/no) |
+| `skills/references/detect-project-kind.sh` | `/max-power` Step 1.3 (file-count + README + source-tree heuristic; prints new/existing) |
+| `skills/references/route-goal.sh` | `/max-power` Step 6.1 (goal-to-skill keyword router; exit codes 0/1/3 = single match / ambiguous / no match) |
+| `skills/references/detect-stack.sh` | `/max-power` Step 1.4 and `/assemble-team` Step 2 (manifest probes for node/python/go/rust/jvm/ruby) |
+| `skills/references/load-env-and-resolve-repo.sh` | `/fix-issue` Step 1 and `/review-pr` Step 1 (safe `.env` load + `REPO` resolver — emits `export` lines for `eval`) |
+| `skills/references/find-test-file.sh` | `/refactor-module` Step 2 and `/fix-issue` Step 3 (convention-based test-file discovery for py/ts/tsx/js/jsx/go/rs/rb) |
 | `skills/references/extract-api-python.sh` | `/generate-docs` Step 1 (Python API surface extraction) |
 | `skills/references/extract-api-typescript.sh` | `/generate-docs` Step 1 (TypeScript/JavaScript API surface extraction) |
+| `skills/references/update-docs-index.sh` | `/generate-docs` Step 4 (regenerates `docs/api/README.md` from H1 + first blockquote of each module page) |
 
 When you write a new skill: if the body grows past ~150 lines or contains a long table /
 checklist / template that would be useful to other skills, extract it to

--- a/scripts/test-references.sh
+++ b/scripts/test-references.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# test-references.sh — Self-test the shared scripts under skills/references/.
+#
+# Mirrors the structure of scripts/test-hooks.sh: every assertion runs against
+# a synthetic input prepared in an isolated temp workspace, the real working
+# tree is never mutated, and a mutation guard at the end fails the run if any
+# tracked file changed.
+#
+# What is tested:
+#   load-env-and-resolve-repo.sh   — empty .env case, DEFAULT_REPO fallback,
+#                                    quoted values (the xargs-bug regression).
+#   detect-stack.sh                — none, single stack, multi-stack, bad dir.
+#   detect-cmp-installation.sh     — full repo (yes), empty dir (no),
+#                                    partial markers (no).
+#   detect-project-kind.sh         — empty dir (new), dir with source tree
+#                                    (existing).
+#   check-spec-gate.sh             — no spec (exit 1), spec present (exit 0
+#                                    with path).
+#   route-goal.sh                  — single match, ambiguous, no match, no
+#                                    input.
+#   find-test-file.sh              — no test (exit 1), conventional test
+#                                    found (exit 0), bad input (exit 2).
+#   update-docs-index.sh           — empty dir (exit 1), dir with modules
+#                                    (writes README.md with table).
+#
+# Usage:
+#   bash scripts/test-references.sh
+#
+# Exit codes:
+#   0 — all reference self-tests passed
+#   1 — at least one self-test failed
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REF_DIR="$REPO_ROOT/skills/references"
+
+if [ ! -d "$REF_DIR" ]; then
+  echo -e "${RED}error:${NC} references directory not found: $REF_DIR" >&2
+  exit 2
+fi
+
+# Mutation guard — same pattern as test-hooks.sh.
+IN_GIT_REPO=0
+WORKTREE_SNAPSHOT=""
+if git -C "$REPO_ROOT" rev-parse --is-inside-work-tree &>/dev/null; then
+  IN_GIT_REPO=1
+  WORKTREE_SNAPSHOT="$(git -C "$REPO_ROOT" status --porcelain)"
+fi
+
+CMP_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/cmp-test-refs.XXXXXX" 2>/dev/null || mktemp -d -t cmp-test-refs.XXXXXX)"
+trap 'rm -rf "$CMP_TMPDIR"' EXIT
+
+pass=0
+fail=0
+
+note() { echo -e "${BLUE}--${NC} $1"; }
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}[PASS]${NC} $label (exit $actual)"
+    pass=$((pass + 1))
+  else
+    echo -e "  ${RED}[FAIL]${NC} $label (expected exit $expected, got $actual)"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}[PASS]${NC} $label"
+    pass=$((pass + 1))
+  else
+    echo -e "  ${RED}[FAIL]${NC} $label (expected '$expected', got '$actual')"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF -- "$needle"; then
+    echo -e "  ${GREEN}[PASS]${NC} $label"
+    pass=$((pass + 1))
+  else
+    echo -e "  ${RED}[FAIL]${NC} $label (string '$needle' not found in output)"
+    echo "$haystack" | head -3 | awk '{print "      " $0}'
+    fail=$((fail + 1))
+  fi
+}
+
+echo ""
+echo -e "${BLUE}== ClaudeMaxPower references self-test ==${NC}"
+echo "Tmp workspace: $CMP_TMPDIR"
+echo ""
+
+# ── load-env-and-resolve-repo.sh ─────────────────────────────────────────────
+note "load-env-and-resolve-repo.sh"
+
+# 1. No .env in cwd → REPO ends up empty.
+WS="$CMP_TMPDIR/load-env-empty"; mkdir -p "$WS"
+set +e
+out=$( cd "$WS" && eval "$(bash "$REF_DIR/load-env-and-resolve-repo.sh")"; echo "REPO=$REPO" )
+rc=$?
+set -e
+assert_exit "no .env -> script exits 0" 0 "$rc"
+assert_eq   "no .env -> REPO is empty" "REPO=" "$out"
+
+# 2. .env with DEFAULT_REPO → REPO resolves to it.
+WS="$CMP_TMPDIR/load-env-default"; mkdir -p "$WS"
+echo "DEFAULT_REPO=owner/repo" > "$WS/.env"
+set +e
+out=$( cd "$WS" && eval "$(bash "$REF_DIR/load-env-and-resolve-repo.sh")"; echo "REPO=$REPO" )
+rc=$?
+set -e
+assert_eq "DEFAULT_REPO -> REPO resolves" "REPO=owner/repo" "$out"
+
+# 3. .env with quoted value containing spaces — the bug the new script fixes.
+# Old `xargs`-based loader broke on this; new line-by-line loader handles it.
+WS="$CMP_TMPDIR/load-env-quoted"; mkdir -p "$WS"
+cat > "$WS/.env" <<'EOF'
+# a comment line
+DEFAULT_REPO="owner/repo"
+EOF
+set +e
+out=$( cd "$WS" && eval "$(bash "$REF_DIR/load-env-and-resolve-repo.sh")"; echo "REPO=$REPO" )
+rc=$?
+set -e
+assert_eq "comment + quoted value parse cleanly" "REPO=owner/repo" "$out"
+
+# ── detect-stack.sh ──────────────────────────────────────────────────────────
+note "detect-stack.sh"
+
+# 1. Empty dir → "none"
+WS="$CMP_TMPDIR/stack-empty"; mkdir -p "$WS"
+out=$(bash "$REF_DIR/detect-stack.sh" "$WS")
+assert_eq "empty dir -> none" "none" "$out"
+
+# 2. package.json only → "node"
+WS="$CMP_TMPDIR/stack-node"; mkdir -p "$WS"
+echo "{}" > "$WS/package.json"
+out=$(bash "$REF_DIR/detect-stack.sh" "$WS")
+assert_eq "package.json -> node" "node" "$out"
+
+# 3. package.json + go.mod → "node,go" (order-stable)
+WS="$CMP_TMPDIR/stack-multi"; mkdir -p "$WS"
+echo "{}" > "$WS/package.json"
+echo "module x" > "$WS/go.mod"
+out=$(bash "$REF_DIR/detect-stack.sh" "$WS")
+assert_eq "node + go -> node,go (order-stable)" "node,go" "$out"
+
+# 4. Bad dir → exit 2
+set +e
+bash "$REF_DIR/detect-stack.sh" "$CMP_TMPDIR/does-not-exist" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "nonexistent dir -> exit 2" 2 "$rc"
+
+# ── detect-cmp-installation.sh ───────────────────────────────────────────────
+note "detect-cmp-installation.sh"
+
+# 1. Full repo → "yes"
+out=$(bash "$REF_DIR/detect-cmp-installation.sh" "$REPO_ROOT")
+assert_eq "real repo -> yes" "yes" "$out"
+
+# 2. Empty dir → "no" (no markers at all)
+WS="$CMP_TMPDIR/cmp-empty"; mkdir -p "$WS"
+out=$(bash "$REF_DIR/detect-cmp-installation.sh" "$WS")
+assert_eq "empty dir -> no" "no" "$out"
+
+# 3. Two of three markers but CLAUDE.md missing the magic string → "no"
+WS="$CMP_TMPDIR/cmp-partial"; mkdir -p "$WS/.claude/hooks" "$WS/skills"
+touch "$WS/.claude/hooks/session-start.sh" "$WS/skills/assemble-team.md"
+echo "# Some other project" > "$WS/CLAUDE.md"
+out=$(bash "$REF_DIR/detect-cmp-installation.sh" "$WS")
+assert_eq "CLAUDE.md missing tag -> no" "no" "$out"
+
+# ── detect-project-kind.sh ───────────────────────────────────────────────────
+note "detect-project-kind.sh"
+
+# 1. Empty dir → "new"
+WS="$CMP_TMPDIR/kind-empty"; mkdir -p "$WS"
+out=$(bash "$REF_DIR/detect-project-kind.sh" "$WS")
+assert_eq "empty dir -> new" "new" "$out"
+
+# 2. Dir with src/ → "existing" (source-tree marker)
+WS="$CMP_TMPDIR/kind-src"; mkdir -p "$WS/src"
+out=$(bash "$REF_DIR/detect-project-kind.sh" "$WS")
+assert_eq "src/ present -> existing" "existing" "$out"
+
+# 3. Dir with non-CMP README → "existing"
+WS="$CMP_TMPDIR/kind-readme"; mkdir -p "$WS"
+echo "# My App" > "$WS/README.md"
+out=$(bash "$REF_DIR/detect-project-kind.sh" "$WS")
+assert_eq "non-CMP README -> existing" "existing" "$out"
+
+# ── check-spec-gate.sh ───────────────────────────────────────────────────────
+note "check-spec-gate.sh"
+
+# 1. No specs → exit 1
+WS="$CMP_TMPDIR/spec-empty"; mkdir -p "$WS"
+set +e
+bash "$REF_DIR/check-spec-gate.sh" "$WS" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "no spec -> exit 1" 1 "$rc"
+
+# 2. Spec present → exit 0, prints path
+WS="$CMP_TMPDIR/spec-present"; mkdir -p "$WS"
+echo "# spec" > "$WS/2026-05-18-foo-design.md"
+set +e
+out=$(bash "$REF_DIR/check-spec-gate.sh" "$WS")
+rc=$?
+set -e
+assert_exit "spec present -> exit 0" 0 "$rc"
+assert_contains "spec path printed to stdout" "$out" "foo-design.md"
+
+# ── route-goal.sh ────────────────────────────────────────────────────────────
+note "route-goal.sh"
+
+# 1. Single match: "add feature" → brainstorming, exit 0
+set +e
+out=$(bash "$REF_DIR/route-goal.sh" "add user authentication")
+rc=$?
+set -e
+assert_exit "feature language -> exit 0" 0 "$rc"
+assert_contains "feature -> /superpowers:brainstorming" "$out" "/superpowers:brainstorming"
+
+# 2. Ambiguous: bug + issue number → exit 1
+set +e
+out=$(bash "$REF_DIR/route-goal.sh" "fix the login bug #42")
+rc=$?
+set -e
+assert_exit "ambiguous -> exit 1" 1 "$rc"
+
+# 3. No match → exit 3
+set +e
+bash "$REF_DIR/route-goal.sh" "wibble wobble" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "unmatched goal -> exit 3" 3 "$rc"
+
+# 4. No input → exit 2
+set +e
+bash "$REF_DIR/route-goal.sh" "" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "empty goal -> exit 2" 2 "$rc"
+
+# ── find-test-file.sh ────────────────────────────────────────────────────────
+note "find-test-file.sh"
+
+# 1. No source file → exit 2
+set +e
+bash "$REF_DIR/find-test-file.sh" "$CMP_TMPDIR/nope.py" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "missing source file -> exit 2" 2 "$rc"
+
+# 2. Source exists but no matching test → exit 1
+WS="$CMP_TMPDIR/find-test-none"; mkdir -p "$WS/src"
+touch "$WS/src/foo.py"
+set +e
+bash "$REF_DIR/find-test-file.sh" "$WS/src/foo.py" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "no matching test -> exit 1" 1 "$rc"
+
+# 3. src-layout: src/foo.py + tests/test_foo.py → exit 0, prints test path
+WS="$CMP_TMPDIR/find-test-srclayout"; mkdir -p "$WS/src" "$WS/tests"
+touch "$WS/src/foo.py" "$WS/tests/test_foo.py"
+set +e
+out=$(bash "$REF_DIR/find-test-file.sh" "$WS/src/foo.py")
+rc=$?
+set -e
+assert_exit "src-layout test found -> exit 0" 0 "$rc"
+assert_contains "src-layout test path printed" "$out" "tests/test_foo.py"
+
+# ── update-docs-index.sh ─────────────────────────────────────────────────────
+note "update-docs-index.sh"
+
+# 1. Empty dir → exit 1 (nothing to index)
+WS="$CMP_TMPDIR/docs-empty"; mkdir -p "$WS"
+set +e
+bash "$REF_DIR/update-docs-index.sh" "$WS" >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit "empty docs dir -> exit 1" 1 "$rc"
+
+# 2. Two modules → exit 0, README.md written with both entries
+WS="$CMP_TMPDIR/docs-modules"; mkdir -p "$WS"
+cat > "$WS/alpha.md" <<'EOF'
+# alpha
+
+> First module description.
+EOF
+cat > "$WS/beta.md" <<'EOF'
+# beta
+
+> Second module description.
+EOF
+set +e
+bash "$REF_DIR/update-docs-index.sh" "$WS" >/dev/null
+rc=$?
+set -e
+assert_exit "two modules -> exit 0" 0 "$rc"
+if [ -f "$WS/README.md" ] && grep -q "alpha" "$WS/README.md" && grep -q "beta" "$WS/README.md"; then
+  echo -e "  ${GREEN}[PASS]${NC} README.md lists both modules"
+  pass=$((pass + 1))
+else
+  echo -e "  ${RED}[FAIL]${NC} README.md missing module entries"
+  fail=$((fail + 1))
+fi
+
+# ── Working-tree mutation guard ──────────────────────────────────────────────
+note "Working-tree mutation guard"
+if [ "$IN_GIT_REPO" = "1" ]; then
+  CURRENT_SNAPSHOT="$(git -C "$REPO_ROOT" status --porcelain)"
+  if [ "$WORKTREE_SNAPSHOT" = "$CURRENT_SNAPSHOT" ]; then
+    echo -e "  ${GREEN}[PASS]${NC} repo working tree unchanged"
+    pass=$((pass + 1))
+  else
+    echo -e "  ${RED}[FAIL]${NC} repo working tree mutated by the test run"
+    diff <(echo "$WORKTREE_SNAPSHOT") <(echo "$CURRENT_SNAPSHOT") | awk '{print "      " $0}'
+    fail=$((fail + 1))
+  fi
+else
+  echo -e "  ${BLUE}--${NC} not in a git repo; mutation guard skipped"
+fi
+
+echo ""
+echo "============================================"
+total=$((pass + fail))
+if [ "$fail" -eq 0 ]; then
+  echo -e "${GREEN}All ${total} reference self-tests passed.${NC}"
+  exit 0
+else
+  echo -e "${RED}${fail} of ${total} reference self-tests failed.${NC}"
+  exit 1
+fi

--- a/skills/assemble-team.md
+++ b/skills/assemble-team.md
@@ -39,12 +39,15 @@ Before analyzing the project or composing any team, verify that the work has bee
 
 **For `new-project` mode:** a design spec MUST exist under `docs/specs/`. If none exists, stop and instruct the user to run `/superpowers:brainstorming <feature>` first (install the Superpowers plugin with `/plugin install superpowers@claude-plugins-official` if not already installed). This is a hard gate — do not proceed, do not spawn agents, do not plan tasks.
 
+Run the shared gate check — it prints the most recent design spec on success and exits 1
+when none exists:
+
 ```bash
-ls docs/specs/*-design.md 2>/dev/null
+SPEC="$(bash skills/references/check-spec-gate.sh docs/specs)" || SPEC=""
 ```
 
-- If the command returns one or more files, read the most recent design spec and use it as the source of truth for Step 2 onwards.
-- If the command returns nothing, respond to the user with:
+- If `$SPEC` is non-empty, read that file and use it as the source of truth for Step 2 onwards.
+- If `$SPEC` is empty (script exited 1), respond to the user with:
 
   > No design spec found in `docs/specs/`. Run `/superpowers:brainstorming <feature>` first to produce an approved spec, then re-run `/assemble-team`. (Install the Superpowers plugin with `/plugin install superpowers@claude-plugins-official` if it isn't already installed.)
 
@@ -53,7 +56,7 @@ ls docs/specs/*-design.md 2>/dev/null
 **For `existing-project` mode:** check for pending specs and evaluate goal concreteness.
 
 ```bash
-ls docs/specs/*-design.md 2>/dev/null
+SPEC="$(bash skills/references/check-spec-gate.sh docs/specs)" || SPEC=""
 ```
 
 - If `--goals` is vague (e.g. "improve the app", "make it better", "modernize", "clean up"), **stop and ask the user explicitly**:
@@ -65,7 +68,7 @@ ls docs/specs/*-design.md 2>/dev/null
   Treat any answer other than an explicit "yes" as no, and stop. Do not silently fall
   through to the team build.
 - If `--goals` is concrete — references GitHub issues (`#10 #11 #12`), specific file TODOs, named features, or points to an existing spec in `docs/specs/` — proceed to Step 1.
-- If specs exist in `docs/specs/`, read them and use them alongside `--goals` when designing the team.
+- If `$SPEC` is non-empty, read it and use it alongside `--goals` when designing the team.
 
 State clearly in the chat: "No implementation until spec is approved — this is the same hard gate enforced by /superpowers:brainstorming."
 
@@ -94,7 +97,11 @@ If mode is missing or invalid, ask the user.
 **For existing-project mode:**
 1. Read the project root: `CLAUDE.md`, `README.md`, `package.json` or `requirements.txt`
 2. Map the directory structure with `Glob("**/*")`
-3. Identify the tech stack (languages, frameworks, test runner)
+3. Identify the tech stack with the shared detector — same probes `/max-power` uses, so
+   results are consistent across skills:
+   ```bash
+   TECH_STACK="$(bash skills/references/detect-stack.sh .)"
+   ```
 4. Parse the goals:
    - If goals reference GitHub issues, fetch them with `gh issue view`
    - If goals are free-text, break them into discrete tasks

--- a/skills/fix-issue.md
+++ b/skills/fix-issue.md
@@ -1,6 +1,7 @@
 ---
 name: fix-issue
 description: Fix a GitHub issue end-to-end — reads the issue, reproduces the bug with a test, fixes the code, and opens a PR.
+disable-model-invocation: true
 arguments:
   - name: issue
     description: GitHub issue number
@@ -29,15 +30,16 @@ Fix a GitHub issue from start to finish, following TDD principles.
 ## Workflow
 
 ### Step 1: Load environment and gate on required arguments
-Load `.env` if it exists, then resolve `--repo`:
+
+Run the shared resolver — it loads `.env` safely (no `xargs`-based word-splitting) and
+resolves `REPO` from `$REPO -> $DEFAULT_REPO`:
 
 ```bash
-[ -f .env ] && export $(grep -v '^#' .env | xargs)
-REPO="${REPO:-$DEFAULT_REPO}"
+eval "$(bash skills/references/load-env-and-resolve-repo.sh)"
 ```
 
-If `REPO` is still empty, **stop and ask the user** (use AskUserQuestion if available, or
-prompt directly): "Which repository should I target? Format: `owner/repo`."
+If `REPO` is still empty after the eval, **stop and ask the user** (use AskUserQuestion if
+available, or prompt directly): "Which repository should I target? Format: `owner/repo`."
 Do not proceed past Step 1 with an empty `REPO`.
 
 If `ISSUE` is missing entirely, ask the user for the issue number before continuing.
@@ -56,6 +58,16 @@ Use Grep and Glob to locate files related to the issue. Look for:
 - Function names mentioned in the issue
 - File paths referenced in the error
 - Related test files
+
+Once you have a likely source file, list its conventional test-file candidates with the
+shared finder (used by `/refactor-module` too — same convention, same output):
+
+```bash
+bash skills/references/find-test-file.sh "$AFFECTED_SRC" || true
+```
+
+If no existing test file is found, you'll create one in Step 4 at the first candidate
+location the script would have printed.
 
 ### Step 4: Write a failing test (TDD first)
 Before touching any implementation:

--- a/skills/generate-docs.md
+++ b/skills/generate-docs.md
@@ -95,16 +95,16 @@ result = function_name(arg1, arg2)
 ```
 
 ### Step 4: Update docs index
-Update or create `docs/api/README.md` with a table of all documented modules:
 
-```markdown
-# API Reference
+Run the shared index generator — it walks `docs/api/*.md`, extracts the H1 + one-line
+description, and writes the table back to `docs/api/README.md`:
 
-| Module | Description |
-|--------|-------------|
-| [foo](foo.md) | <one-liner> |
-| [bar](bar.md) | <one-liner> |
+```bash
+bash skills/references/update-docs-index.sh docs/api
 ```
+
+The script is fully deterministic — running it twice on the same input produces byte-
+identical output. No AI judgment is needed for the index regeneration.
 
 ### Step 5: Report
 Tell the user:

--- a/skills/max-power.md
+++ b/skills/max-power.md
@@ -1,6 +1,7 @@
 ---
 name: max-power
 description: One-command activation — installs ClaudeMaxPower, offers Superpowers plugin install, presents capabilities menu, and routes the user to the right skill for their immediate goal.
+disable-model-invocation: true
 arguments:
   - name: goal
     description: What you want to accomplish right now (free text; the skill picks the best entry point)
@@ -59,59 +60,35 @@ pre-commit, fix-issue, review-pr) require git.
 
 ### 1.2 ClaudeMaxPower already installed?
 
-ClaudeMaxPower is considered installed when all three markers are present:
+Run the shared detector — it checks three install markers (hook script, assemble-team skill,
+CMP-tagged CLAUDE.md) and prints `yes` or `no`:
 
-- `.claude/hooks/session-start.sh` exists
-- `skills/assemble-team.md` exists
-- `CLAUDE.md` exists and contains the string `ClaudeMaxPower`
-
-Record `CMP_INSTALLED=yes|no`.
+```bash
+CMP_INSTALLED="$(bash skills/references/detect-cmp-installation.sh .)"
+```
 
 ### 1.3 New or existing project?
 
-Count source files that are not part of ClaudeMaxPower:
+Run the shared classifier — it applies the file-count + README + source-tree heuristic
+and prints `new` or `existing`:
 
 ```bash
-# Rough heuristic — count files outside .claude, skills, docs, scripts, workflows.
-# Use `*/X/*` (not `./X/*`) so nested vendor/build dirs are also excluded —
-# a project with sub-package node_modules or examples/.venv otherwise drowns
-# the count and forces a false `existing` classification.
-find . -type f \
-  -not -path './.git/*' \
-  -not -path './.claude/*' \
-  -not -path './skills/*' \
-  -not -path './docs/*' \
-  -not -path './scripts/*' \
-  -not -path './workflows/*' \
-  -not -path '*/node_modules/*' \
-  -not -path '*/.venv/*' \
-  -not -path '*/__pycache__/*' \
-  -not -path '*/dist/*' \
-  -not -path '*/build/*' \
-  -not -path '*/target/*' \
-  | wc -l
+PROJECT_KIND="$(bash skills/references/detect-project-kind.sh .)"
 ```
-
-If fewer than 10 non-CMP files AND no `README.md` (or only the CMP one) AND no source tree
-(`src/`, `app/`, `lib/`, package.json, pyproject.toml, go.mod, Cargo.toml): `PROJECT_KIND=new`.
-Otherwise: `PROJECT_KIND=existing`.
 
 The `mode` argument overrides detection. If `mode=new-project` or `mode=existing-project`,
 use that value. Otherwise use the detection result.
 
 ### 1.4 Detect tech stack
 
-Probe for each and record which exist:
+Run the shared detector — same probes as `/assemble-team` uses, so results are consistent:
 
-- `package.json` -> Node/JS/TS
-- `requirements.txt`, `pyproject.toml`, `Pipfile` -> Python
-- `go.mod` -> Go
-- `Cargo.toml` -> Rust
-- `pom.xml`, `build.gradle` -> Java/JVM
-- `Gemfile` -> Ruby
+```bash
+TECH_STACK="$(bash skills/references/detect-stack.sh .)"
+```
 
-Record `TECH_STACK` as a comma-separated list. Used later to tailor pre-commit checks and
-test runners.
+Output is comma-separated (`node,python,go`...) or `none`. Used later to tailor pre-commit
+checks and test runners.
 
 ## Step 2 — Install ClaudeMaxPower (only if not present)
 
@@ -185,26 +162,28 @@ contents unless the user asks.
 
 ### 6.1 If a `goal` argument was provided, classify it
 
-Match against these intent keywords (case-insensitive, any match counts):
+Run the shared router — it does the keyword-table lookup deterministically and prints the
+matched skill plus a one-line rationale:
 
-| Keywords | Route |
-|---------|------|
-| `bug`, `fix`, `error`, `broken`, `crash`, `regression` | `/superpowers:systematic-debugging` (or `/fix-issue` if a GitHub issue number is mentioned) |
-| `new feature`, `add`, `build`, `create`, `implement` | `/superpowers:brainstorming` (hard gate) |
-| `review`, `pr`, `pull request` | `/review-pr` |
-| `refactor`, `rename`, `extract`, `cleanup` | `/refactor-module` |
-| `test`, `tdd`, `coverage` | `/superpowers:test-driven-development` |
-| `docs`, `readme`, `documentation` | `/generate-docs` |
-| `team`, `parallel`, `several tasks` | `/assemble-team` |
-| `commit message`, `commit msg`, `conventional commit` | `/gen-commit-message` |
+```bash
+bash skills/references/route-goal.sh "$GOAL"
+```
 
-When you route, do not execute the downstream skill yourself. Tell the user the exact
-command to run and a one-line rationale. Example:
+Exit codes:
+
+- `0` — one route matched. Stdout is `<skill>\t<rationale>`. Tell the user the exact
+  command to run, prefixed with the rationale. Do not execute the downstream skill
+  yourself.
+- `1` — multiple routes matched. Stdout lists each candidate. Ask the user which one they
+  meant before routing.
+- `3` — nothing matched. Fall through to Step 6.2 (show the menu).
+
+Example output when one route matches:
 
 ```
 Route: /superpowers:brainstorming user-auth
-Why: you asked to "add authentication" — we brainstorm the spec first (hard gate) before
-any code is written. Install the Superpowers plugin first with
+Why: Feature/build language — brainstorming is the hard gate before any new code.
+Install the Superpowers plugin first with
 /plugin install superpowers@claude-plugins-official if it's not already active.
 ```
 

--- a/skills/refactor-module.md
+++ b/skills/refactor-module.md
@@ -35,11 +35,17 @@ Read the full implementation file. Understand:
 - Any TODOs or known issues
 
 ### Step 2: Find and read the test file
-Look for a corresponding test file:
+
+Run the shared test-file finder — it knows the conventional paths for Python, TS/JS, Go,
+Rust, and Ruby and prints each existing candidate in priority order:
+
 ```bash
-# Examples: tests/test_foo.py, __tests__/foo.test.ts, foo.spec.js
+TEST_FILES="$(bash skills/references/find-test-file.sh "$FILE")" || TEST_FILES=""
 ```
-If no test file exists, stop and tell the user. A refactor without tests is risky.
+
+If `$TEST_FILES` is empty (script exited 1), stop and tell the user. A refactor without
+tests is risky. If multiple candidates exist, prefer the first line (priority order in the
+script reflects project conventions).
 
 ### Step 3: Capture test baseline
 ```bash

--- a/skills/references/check-spec-gate.sh
+++ b/skills/references/check-spec-gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Check whether an approved design spec exists in docs/specs/.
+# Used by /assemble-team Step 0 (the brainstorming hard gate).
+#
+# Usage: bash skills/references/check-spec-gate.sh [docs-dir]
+#
+# Output (stdout): path of the most recent matching spec when one exists.
+#
+# Exit codes:
+#   0 — at least one spec found (most-recent path printed to stdout)
+#   1 — no spec found (caller should stop and route to /superpowers:brainstorming)
+
+set -euo pipefail
+
+DOCS_DIR="${1:-docs/specs}"
+
+shopt -s nullglob
+specs=( "$DOCS_DIR"/*-design.md )
+shopt -u nullglob
+
+if [ "${#specs[@]}" -eq 0 ]; then
+  exit 1
+fi
+
+# Most-recently modified spec wins. Portable across GNU/BSD stat by using `ls -t`.
+ls -t "${specs[@]}" | head -n 1

--- a/skills/references/detect-cmp-installation.sh
+++ b/skills/references/detect-cmp-installation.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Detect whether ClaudeMaxPower is installed in the given directory.
+# Used by /max-power Step 1.2.
+#
+# Usage: bash skills/references/detect-cmp-installation.sh [directory]
+#
+# Output (stdout): "yes" or "no"
+# Exit codes: 0 always (status is communicated via stdout, not exit code)
+#
+# CMP is considered installed when ALL THREE markers are present:
+#   1. .claude/hooks/session-start.sh exists
+#   2. skills/assemble-team.md exists
+#   3. CLAUDE.md exists AND contains the string "ClaudeMaxPower"
+
+set -euo pipefail
+
+DIR="${1:-.}"
+
+if [ ! -f "$DIR/.claude/hooks/session-start.sh" ]; then
+  echo "no"
+  exit 0
+fi
+
+if [ ! -f "$DIR/skills/assemble-team.md" ]; then
+  echo "no"
+  exit 0
+fi
+
+if [ ! -f "$DIR/CLAUDE.md" ] || ! grep -q "ClaudeMaxPower" "$DIR/CLAUDE.md"; then
+  echo "no"
+  exit 0
+fi
+
+echo "yes"

--- a/skills/references/detect-project-kind.sh
+++ b/skills/references/detect-project-kind.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Classify a directory as a "new" or "existing" project.
+# Used by /max-power Step 1.3.
+#
+# Usage: bash skills/references/detect-project-kind.sh [directory]
+#
+# Output (stdout): "new" or "existing"
+# Exit codes: 0 always
+#
+# A directory is "new" when ALL of the following hold:
+#   * fewer than 10 non-CMP, non-vendor, non-build files
+#   * no README.md OR only the CMP README
+#   * no source tree marker (src/, app/, lib/, package.json, pyproject.toml,
+#     go.mod, Cargo.toml)
+# Otherwise it is "existing".
+
+set -euo pipefail
+
+DIR="${1:-.}"
+
+if [ ! -d "$DIR" ]; then
+  echo "Not a directory: $DIR" >&2
+  exit 2
+fi
+
+file_count="$(
+  find "$DIR" -type f \
+    -not -path "$DIR/.git/*" \
+    -not -path "$DIR/.claude/*" \
+    -not -path "$DIR/skills/*" \
+    -not -path "$DIR/docs/*" \
+    -not -path "$DIR/scripts/*" \
+    -not -path "$DIR/workflows/*" \
+    -not -path '*/node_modules/*' \
+    -not -path '*/.venv/*' \
+    -not -path '*/__pycache__/*' \
+    -not -path '*/dist/*' \
+    -not -path '*/build/*' \
+    -not -path '*/target/*' \
+    | wc -l
+)"
+file_count="${file_count//[[:space:]]/}"
+
+has_real_readme="no"
+if [ -f "$DIR/README.md" ]; then
+  if ! grep -q "ClaudeMaxPower" "$DIR/README.md"; then
+    has_real_readme="yes"
+  fi
+fi
+
+has_source_tree="no"
+for marker in src app lib package.json pyproject.toml go.mod Cargo.toml; do
+  if [ -e "$DIR/$marker" ]; then
+    has_source_tree="yes"
+    break
+  fi
+done
+
+if [ "$file_count" -lt 10 ] && [ "$has_real_readme" = "no" ] && [ "$has_source_tree" = "no" ]; then
+  echo "new"
+else
+  echo "existing"
+fi

--- a/skills/references/detect-stack.sh
+++ b/skills/references/detect-stack.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Detect the project's tech stack by probing manifest files.
+# Shared by /max-power Step 1.4 and /assemble-team Step 2.
+#
+# Usage: bash skills/references/detect-stack.sh [directory]
+#
+# Output: comma-separated list of detected stacks on stdout, or "none" if nothing matched.
+# Detection is order-stable so consumers can diff results across runs.
+
+set -euo pipefail
+
+DIR="${1:-.}"
+
+if [ ! -d "$DIR" ]; then
+  echo "Not a directory: $DIR" >&2
+  exit 2
+fi
+
+stacks=()
+
+[ -f "$DIR/package.json" ]      && stacks+=("node")
+{ [ -f "$DIR/requirements.txt" ] || [ -f "$DIR/pyproject.toml" ] || [ -f "$DIR/Pipfile" ]; } \
+                                && stacks+=("python")
+[ -f "$DIR/go.mod" ]            && stacks+=("go")
+[ -f "$DIR/Cargo.toml" ]        && stacks+=("rust")
+{ [ -f "$DIR/pom.xml" ] || [ -f "$DIR/build.gradle" ] || [ -f "$DIR/build.gradle.kts" ]; } \
+                                && stacks+=("jvm")
+[ -f "$DIR/Gemfile" ]           && stacks+=("ruby")
+
+if [ "${#stacks[@]}" -eq 0 ]; then
+  echo "none"
+else
+  ( IFS=','; echo "${stacks[*]}" )
+fi

--- a/skills/references/find-test-file.sh
+++ b/skills/references/find-test-file.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# List candidate test-file paths for a given source file, in priority order.
+# Used by /refactor-module Step 2 and /fix-issue Step 4.
+#
+# Usage: bash skills/references/find-test-file.sh <source-file>
+#
+# Output (stdout): one candidate path per line, in priority order.
+#   Only paths that actually exist are printed.
+#
+# Exit codes:
+#   0 — at least one existing test file found
+#   1 — no existing test file found (caller decides whether to stop or create one)
+#   2 — bad input (no source file given, or it doesn't exist)
+
+set -euo pipefail
+
+SRC="${1:-}"
+if [ -z "$SRC" ] || [ ! -f "$SRC" ]; then
+  echo "Usage: $0 <existing-source-file>" >&2
+  exit 2
+fi
+
+dir="$(dirname "$SRC")"
+base="$(basename "$SRC")"
+name="${base%.*}"
+ext="${base##*.}"
+
+candidates=()
+
+case "$ext" in
+  py)
+    # Walk up from the source file's dir to find a sibling tests/ directory.
+    # Covers the common src-layout: pkg/src/foo.py paired with pkg/tests/test_foo.py.
+    parent="$(dirname "$dir")"
+    candidates+=(
+      "${dir}/test_${name}.py"
+      "${dir}/tests/test_${name}.py"
+      "${parent}/tests/test_${name}.py"
+      "${parent}/tests/${name}_test.py"
+      "${parent}/test/test_${name}.py"
+      "tests/test_${name}.py"
+      "tests/${name}_test.py"
+      "test/test_${name}.py"
+    )
+    ;;
+  ts|tsx|js|jsx|mjs|cjs)
+    candidates+=(
+      "${dir}/__tests__/${name}.test.${ext}"
+      "${dir}/${name}.test.${ext}"
+      "${dir}/${name}.spec.${ext}"
+      "__tests__/${name}.test.${ext}"
+      "tests/${name}.test.${ext}"
+    )
+    ;;
+  go)
+    candidates+=( "${dir}/${name}_test.go" )
+    ;;
+  rs)
+    candidates+=( "${dir}/${name}_test.rs" "tests/${name}.rs" )
+    ;;
+  rb)
+    candidates+=( "spec/${name}_spec.rb" "test/${name}_test.rb" )
+    ;;
+  *)
+    echo "Unsupported extension: .$ext" >&2
+    exit 2
+    ;;
+esac
+
+found=0
+for c in "${candidates[@]}"; do
+  if [ -f "$c" ]; then
+    echo "$c"
+    found=1
+  fi
+done
+
+[ "$found" -eq 1 ] || exit 1

--- a/skills/references/load-env-and-resolve-repo.sh
+++ b/skills/references/load-env-and-resolve-repo.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Load .env (if present) and resolve REPO from $REPO -> $DEFAULT_REPO.
+# Shared by /fix-issue and /review-pr Step 1.
+#
+# Usage:  eval "$(bash skills/references/load-env-and-resolve-repo.sh)"
+#
+# Output (on stdout, intended to be eval'd):
+#   export REPO="<owner/repo>"          when REPO or DEFAULT_REPO resolves
+#   exit-code 0 with REPO unset         when neither is set — caller must ask the user
+#
+# Exit codes:
+#   0 — env loaded; check whether $REPO is non-empty before proceeding
+#   2 — .env is malformed (lines that are not KEY=VALUE)
+
+set -euo pipefail
+
+if [ -f .env ]; then
+  # Filter comments and blank lines, validate KEY=VALUE shape, then export.
+  while IFS= read -r line; do
+    case "$line" in
+      ''|\#*) continue ;;
+      *=*)   printf 'export %s\n' "$line" ;;
+      *)     echo "# malformed .env line ignored: $line" >&2 ;;
+    esac
+  done < .env
+fi
+
+# Resolve REPO: explicit env wins, then DEFAULT_REPO from .env, then empty.
+printf 'export REPO="${REPO:-${DEFAULT_REPO:-}}"\n'

--- a/skills/references/route-goal.sh
+++ b/skills/references/route-goal.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Route a free-text goal string to a recommended skill.
+# Used by /max-power Step 6.1.
+#
+# Usage: bash skills/references/route-goal.sh "<goal text>"
+#
+# Output (stdout):
+#   <route>\t<rationale>
+#
+# Exit codes:
+#   0 — exactly one route matched (deterministic)
+#   1 — multiple routes matched (ambiguous — caller should ask the user)
+#   2 — no goal provided
+#   3 — no route matched (caller should show the menu)
+#
+# Matching is case-insensitive, whole-word, first-keyword-wins within each route.
+# Order of routes matters: more-specific routes first.
+
+set -euo pipefail
+
+GOAL="${1:-}"
+if [ -z "$GOAL" ]; then
+  exit 2
+fi
+
+# Lowercase for matching.
+g="$(printf '%s' "$GOAL" | tr '[:upper:]' '[:lower:]')"
+
+# Each route: <skill>|<one-line rationale>|<space-separated keyword list>
+# Note: "build" deliberately appears under "new feature" not "fix", so "rebuild" classifies as a feature.
+routes=(
+  "/fix-issue|GitHub issue number detected — fix-issue handles it end-to-end with TDD.|#[0-9]"
+  "/superpowers:systematic-debugging|Symptom language suggests a bug — start with root cause investigation.|bug fix error broken crash regression"
+  "/review-pr|PR/review language detected — review-pr handles the full review flow.|review pr pull request"
+  "/refactor-module|Refactor/rename language detected — refactor-module is the safe path with test baseline.|refactor rename extract cleanup"
+  "/superpowers:test-driven-development|Test/TDD/coverage language — start with the strict TDD loop.|test tdd coverage"
+  "/generate-docs|Docs/readme language — generate-docs scans source and writes docs/api/.|docs readme documentation"
+  "/assemble-team|Multiple-task language — assemble-team coordinates parallel agents.|team parallel several tasks"
+  "/gen-commit-message|Commit-message language — gen-commit-message reads the staged diff and proposes one.|commit message conventional commit"
+  "/superpowers:brainstorming|Feature/build language — brainstorming is the hard gate before any new code.|new feature add build create implement"
+)
+
+matched=()
+for entry in "${routes[@]}"; do
+  IFS='|' read -r skill rationale keywords <<<"$entry"
+  for kw in $keywords; do
+    # Special-case: issue-number pattern (#NNN)
+    if [ "$kw" = "#[0-9]" ]; then
+      if printf '%s' "$g" | grep -qE '#[0-9]+'; then
+        matched+=("$skill|$rationale")
+        break
+      fi
+      continue
+    fi
+    # Word-boundary match on lowercased goal.
+    if printf '%s' "$g" | grep -qwE "$kw"; then
+      matched+=("$skill|$rationale")
+      break
+    fi
+  done
+done
+
+case "${#matched[@]}" in
+  0) exit 3 ;;
+  1)
+    IFS='|' read -r skill rationale <<<"${matched[0]}"
+    printf '%s\t%s\n' "$skill" "$rationale"
+    exit 0
+    ;;
+  *)
+    # Ambiguous — print all matches so the caller can ask the user.
+    for m in "${matched[@]}"; do
+      IFS='|' read -r skill rationale <<<"$m"
+      printf '%s\t%s\n' "$skill" "$rationale"
+    done
+    exit 1
+    ;;
+esac

--- a/skills/references/update-docs-index.sh
+++ b/skills/references/update-docs-index.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Regenerate docs/api/README.md from every *.md file in docs/api/.
+# Used by /generate-docs Step 4.
+#
+# Usage: bash skills/references/update-docs-index.sh [docs-api-dir]
+#
+# Output: writes <dir>/README.md (overwriting). Prints the count of modules indexed.
+# Exit codes:
+#   0 — README.md written
+#   1 — directory has no module files (nothing to index)
+#   2 — bad input
+#
+# Convention:
+#   * Module name = first H1 line ("# foo")
+#   * One-liner   = first blockquote line that immediately follows the H1 ("> ...")
+#                   or, if no blockquote, the first non-empty paragraph line.
+
+set -euo pipefail
+
+DIR="${1:-docs/api}"
+
+if [ ! -d "$DIR" ]; then
+  echo "Not a directory: $DIR" >&2
+  exit 2
+fi
+
+shopt -s nullglob
+modules=( "$DIR"/*.md )
+shopt -u nullglob
+
+# Drop README.md itself from the input set.
+filtered=()
+for f in "${modules[@]}"; do
+  case "$(basename "$f")" in
+    README.md) continue ;;
+    *) filtered+=( "$f" ) ;;
+  esac
+done
+
+if [ "${#filtered[@]}" -eq 0 ]; then
+  exit 1
+fi
+
+# Sort alphabetically for stable output.
+IFS=$'\n' sorted=( $(printf '%s\n' "${filtered[@]}" | sort) )
+unset IFS
+
+out="$DIR/README.md"
+{
+  echo "# API Reference"
+  echo ""
+  echo "| Module | Description |"
+  echo "|--------|-------------|"
+
+  for f in "${sorted[@]}"; do
+    base="$(basename "$f" .md)"
+    title="$(awk '/^# / { sub(/^# /, ""); print; exit }' "$f")"
+    [ -z "$title" ] && title="$base"
+
+    # Prefer the first blockquote line after the H1; fall back to the first
+    # non-empty, non-heading line.
+    desc="$(awk '
+      /^# / { seen=1; next }
+      seen && /^> / { sub(/^> /, ""); print; exit }
+      seen && /^[^#> ]/ && NF > 0 { print; exit }
+    ' "$f")"
+    [ -z "$desc" ] && desc="(no description)"
+
+    printf '| [%s](%s.md) | %s |\n' "$base" "$base" "$desc"
+  done
+} > "$out"
+
+echo "${#sorted[@]} module(s) indexed -> $out"

--- a/skills/review-pr.md
+++ b/skills/review-pr.md
@@ -1,6 +1,7 @@
 ---
 name: review-pr
 description: Full PR review — reads the diff, checks for bugs/security/tests/style, and posts a structured review comment via GitHub CLI.
+disable-model-invocation: true
 arguments:
   - name: pr
     description: Pull request number
@@ -26,13 +27,16 @@ Perform a thorough code review of a GitHub pull request and post structured feed
 ## Workflow
 
 ### Step 1: Load environment and gate on required arguments
+
+Run the shared resolver — it loads `.env` safely and resolves `REPO` from
+`$REPO -> $DEFAULT_REPO`:
+
 ```bash
-[ -f .env ] && export $(grep -v '^#' .env | xargs)
-REPO="${REPO:-$DEFAULT_REPO}"
+eval "$(bash skills/references/load-env-and-resolve-repo.sh)"
 ```
 
-If `REPO` is still empty, **stop and ask the user** (use AskUserQuestion if available, or
-prompt directly): "Which repository should I target? Format: `owner/repo`."
+If `REPO` is still empty after the eval, **stop and ask the user** (use AskUserQuestion if
+available, or prompt directly): "Which repository should I target? Format: `owner/repo`."
 Do not proceed past Step 1 with an empty `REPO`.
 
 If `PR` is missing, ask the user for the PR number before continuing.

--- a/skills/superpowers-redirect.md
+++ b/skills/superpowers-redirect.md
@@ -1,6 +1,7 @@
 ---
 name: superpowers-redirect
 description: Use when user types /brainstorming, /writing-plans, /subagent-dev, /tdd-loop, /systematic-debugging, /using-worktrees, or /finish-branch — these moved to the Superpowers plugin. Routes the user to the canonical /superpowers:* command.
+user-invocable: false
 arguments: []
 allowed-tools:
   - Read


### PR DESCRIPTION
## Summary

Three-axis audit of the eight native ClaudeMaxPower skills.

**Visibility (frontmatter)**
- `fix-issue`, `review-pr`, `max-power` — added `disable-model-invocation: true`. These are the only skills with hard-to-reverse or workspace-modifying side effects (open PRs / post public review comments / run install + setup.sh). The model can still recommend them; the user must explicitly type the `/`.
- `superpowers-redirect` — added `user-invocable: false`. The skill fires on legacy `/brainstorming`-style input; no one types `/superpowers-redirect`, so it should not appear in `/menu`.
- `assemble-team`, `generate-docs`, `refactor-module`, `gen-commit-message` — deliberately left model-invocable.

**Determinism — 8 new scripts under `skills/references/`**
| Script | Replaces |
|---|---|
| `load-env-and-resolve-repo.sh` | Duplicated `.env` + `REPO` resolution in `fix-issue` and `review-pr`; also fixes a latent `xargs`-based bug on values with spaces/quotes |
| `detect-stack.sh` | Manifest probes in `max-power` 1.4 and `assemble-team` Step 2 |
| `detect-cmp-installation.sh` | 3-marker install check in `max-power` 1.2 |
| `detect-project-kind.sh` | File-count + README + source-tree heuristic in `max-power` 1.3 |
| `check-spec-gate.sh` | Brainstorming spec-gate check in `assemble-team` Step 0 (both modes) |
| `route-goal.sh` | Goal-to-skill keyword router in `max-power` 6.1 (exit codes 0/1/3 = single / ambiguous / no-match) |
| `find-test-file.sh` | Convention-based test-file discovery in `refactor-module` 2 and `fix-issue` 3 (py/ts/tsx/js/jsx/go/rs/rb + src-layout fallback) |
| `update-docs-index.sh` | `docs/api/README.md` table regeneration in `generate-docs` 4 |

**Composability — duplicated logic eliminated**
- `.env` + `REPO` resolution (was in `fix-issue` + `review-pr`)
- Tech-stack detection (was in `max-power` + `assemble-team`)
- Test-file convention lookup (was in `refactor-module` + `fix-issue`)
- Spec-gate check (was duplicated across `assemble-team`'s two modes)

**Documentation**
- `docs/skills-guide.md` reference-table extended to register all 8 new helpers (caught during self-review; would have left readers of the doc ignorant of the new scripts).

**Tests**
- `scripts/test-references.sh` — new harness mirroring `scripts/test-hooks.sh`. 30 assertions across the 8 new scripts, with the same mutation-guard contract. Runs cleanly from a temp workspace; never touches the real working tree. CI integration (adding it as a gating job in `.github/workflows/ci.yml`) is a deliberate follow-up.

## Self-review note

Initially also extracted the per-skill feedback-footer into `feedback-prompt.md`, but reverted before commit: the replacement (`[Feedback prompt — see ...]`) replaced user-visible text with a bracket pointer that would either need an extra `Read` to render or just display literally. The 16 lines of duplication weren't worth the UX cost.

## Test plan

- [x] `bash scripts/validate-skills.sh --strict` — all 12 skill + agent files PASS
- [x] `bash scripts/test-hooks.sh` — all 21 hook self-tests PASS, working tree unchanged
- [x] `bash scripts/test-references.sh` — all 30 reference self-tests PASS, working tree unchanged
- [x] Each new script smoke-tested with success, failure, and ambiguous inputs against documented exit codes
- [x] `find-test-file.sh` caught a real src-layout gap during testing (`examples/todo-app/src/todo.py` -> `examples/todo-app/tests/test_todo.py`) and was fixed
- [ ] CI gating jobs (shellcheck, actionlint, secret scan, smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)