### PR TITLE
fix(rules): collapse three soft duplications across CLAUDE.md and rules/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,16 +72,15 @@ against the code before applying it. Details:
 
 ## Workflow
 
-```
-Idea
- ├─ /superpowers:brainstorming                 → docs/specs/YYYY-MM-DD-<topic>-design.md (hard gate)
- ├─ /superpowers:writing-plans                 → docs/plans/YYYY-MM-DD-<topic>-plan.md
- ├─ /superpowers:using-git-worktrees           → isolated branch workspace
- ├─ /superpowers:subagent-driven-development   → fresh subagent per task + two-stage review
- │    └─ /superpowers:test-driven-development      (strict Red-Green-Refactor)
- │    └─ /superpowers:systematic-debugging         (root cause before fix)
- └─ /superpowers:finishing-a-development-branch → merge / PR / keep / discard + worktree cleanup
-```
+The unified Superpowers pipeline, in order:
+`/superpowers:brainstorming` (hard gate) → `/superpowers:writing-plans` →
+`/superpowers:using-git-worktrees` → `/superpowers:subagent-driven-development`
+(invokes `/superpowers:test-driven-development` and `/superpowers:systematic-debugging`
+as needed) → `/superpowers:finishing-a-development-branch`.
+
+Full diagram with deliverables, hard-gate annotations, and per-step iron-law tags:
+[`rules/20-workflow.md`](./rules/20-workflow.md). That file is the canonical source — if
+the pipeline changes, edit it there and let this paragraph re-summarize on the next pass.
 
 Methodology skills live upstream — install with
 `/plugin install superpowers@claude-plugins-official`.

--- a/rules/30-git-github-ci.md
+++ b/rules/30-git-github-ci.md
@@ -16,11 +16,9 @@ commit time is owned by [60-security-privacy.md](60-security-privacy.md).
 - Use **Conventional Commits** format: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`,
   `test:`.
 - Subject lines stay short; details go in the body.
-- The deterministic pre-commit checks (secret scan, debug-statement scan, large-file warning,
-  linter pass) run automatically via `.claude/hooks/pre-commit-check.sh` — no skill
-  invocation needed before `git commit`.
-- The LLM-judgment portion of the old `/pre-commit` skill (proposing the message itself)
-  lives in `/gen-commit-message` — see [40-skills.md](40-skills.md).
+- For what the pre-commit hook checks and how `/gen-commit-message` fits in, see
+  [40-skills.md § Invocation Discipline](40-skills.md#invocation-discipline) — that file
+  owns the full description so the two policies do not drift apart.
 
 ## Branch Finishing
 


### PR DESCRIPTION
## Summary

A follow-up audit of `rules/` found no contradictions and no hard duplications, but three soft duplications where the same fact appears in two files with near-identical wording. Each is a drift hazard.

This PR collapses all three.

## Changes

1. **`CLAUDE.md` Workflow diagram** — was a near-verbatim copy of the pipeline diagram in `rules/20-workflow.md`. Subtle wording drift was already present (the `(iron law)` tag was in one but not the other). Replaced the CLAUDE.md diagram with a compressed prose summary that names every step and points at `20-workflow.md` as the canonical source.

2. **`rules/30-git-github-ci.md` § Commit Messages** — enumerated the pre-commit hook's checks (secret scan, debug-statement scan, large-file warning, linter) in language nearly identical to the canonical statement in `rules/40-skills.md § Invocation Discipline`. Replaced with a one-line pointer.

3. **"LLM portion of the old `/pre-commit`" framing** — appeared in both `30-git-github-ci.md` and `40-skills.md` with the same wording. Removed from `30`; `40` keeps the canonical phrasing.

Net: 12 insertions, 15 deletions. `CLAUDE.md` stays under 200 lines (now 193, per the maintenance rule).

## Why now

PR #44 split the rule corpus from the monolithic `CLAUDE.md` into `rules/`. That extraction left these duplications behind — they were tolerable in a single-file world but actively dangerous in a multi-file one, because the maintenance contract in `rules/90-maintenance.md` now says "a rule is stated once" and "broader files reference the specific file instead of repeating the rule".

## Test plan

- [x] `bash scripts/validate-skills.sh --strict` — all 12 skill + agent files PASS
- [x] `bash scripts/test-hooks.sh` — all 21 hook self-tests PASS, working tree unchanged
- [x] `wc -l CLAUDE.md` → 193 (still under the 200-line maintenance limit)
- [x] Anchor target `rules/40-skills.md#invocation-discipline` exists (verified at line 74)
- [ ] CI gating jobs (shellcheck, actionlint, secret scan, smoke, lint markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)