### PR TITLE
ci: add test-references.sh to the Cross-Platform Smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Self-test hook scripts
         run: bash scripts/test-hooks.sh
 
+      - name: Self-test shared reference scripts
+        run: bash scripts/test-references.sh
+
   check-structure:
     name: Verify Project Structure
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

#45 introduced `scripts/test-references.sh` (30-assertion self-test harness for the 8 new shared scripts under `skills/references/`), but it was not wired into CI — only the pre-existing `test-hooks.sh` ran on every PR. Future edits to the shared helpers could regress silently.

This change adds a third step to the `cross-platform-smoke` job so the harness runs on Ubuntu, macOS, and Windows for every PR, mirroring the treatment of `test-hooks.sh`.

## Diff

```yaml
       - name: Self-test hook scripts
         run: bash scripts/test-hooks.sh

+      - name: Self-test shared reference scripts
+        run: bash scripts/test-references.sh
```

That's it. 3 added lines.

## Note on `scripts/verify-ci.sh`

The local CI mirror script doesn't currently cover the `cross-platform-smoke` job at all (it only mirrors the 5 gating jobs listed in its own docstring). So no update to `verify-ci.sh` is needed for this change. If we later decide to mirror cross-platform-smoke locally, `test-references.sh` should be added alongside `test-hooks.sh` and `validate-skills.sh` in the same change.

## Test plan

- [x] `bash scripts/test-references.sh` → 30/30 PASS, working tree clean
- [x] `bash scripts/test-hooks.sh` → 21/21 PASS, working tree clean
- [x] `bash scripts/validate-skills.sh --strict` → all PASS
- [ ] CI: shellcheck (will lint the YAML edit indirectly via actionlint), actionlint, cross-platform-smoke on all 3 OSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)