### PR TITLE
refactor(skills): close 3 residual gaps from the #45 audit

### DIFF
--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -205,6 +205,7 @@ Current reference files:
 | `skills/references/detect-stack.sh` | `/max-power` Step 1.4 and `/assemble-team` Step 2 (manifest probes for node/python/go/rust/jvm/ruby) |
 | `skills/references/load-env-and-resolve-repo.sh` | `/fix-issue` Step 1 and `/review-pr` Step 1 (safe `.env` load + `REPO` resolver — emits `export` lines for `eval`) |
 | `skills/references/find-test-file.sh` | `/refactor-module` Step 2 and `/fix-issue` Step 3 (convention-based test-file discovery for py/ts/tsx/js/jsx/go/rs/rb) |
+| `skills/references/run-tests.sh` | `/fix-issue` Steps 4 + 6 and `/refactor-module` Steps 3 + 6 (stack-aware test runner — pytest for Python, `npm test` for Node; exit 2 for unsupported stacks) |
 | `skills/references/extract-api-python.sh` | `/generate-docs` Step 1 (Python API surface extraction) |
 | `skills/references/extract-api-typescript.sh` | `/generate-docs` Step 1 (TypeScript/JavaScript API surface extraction) |
 | `skills/references/update-docs-index.sh` | `/generate-docs` Step 4 (regenerates `docs/api/README.md` from H1 + first blockquote of each module page) |

--- a/scripts/test-references.sh
+++ b/scripts/test-references.sh
@@ -22,6 +22,9 @@
 #                                    found (exit 0), bad input (exit 2).
 #   update-docs-index.sh           — empty dir (exit 1), dir with modules
 #                                    (writes README.md with table).
+#   run-tests.sh                   — bad target (exit 3), unsupported stack
+#                                    (exit 2 with hint), python stack routes
+#                                    to pytest (verified via dry-runnable env).
 #
 # Usage:
 #   bash scripts/test-references.sh
@@ -315,6 +318,51 @@ if [ -f "$WS/README.md" ] && grep -q "alpha" "$WS/README.md" && grep -q "beta" "
   pass=$((pass + 1))
 else
   echo -e "  ${RED}[FAIL]${NC} README.md missing module entries"
+  fail=$((fail + 1))
+fi
+
+# ── run-tests.sh ─────────────────────────────────────────────────────────────
+note "run-tests.sh"
+
+# 1. Bad target -> exit 3 (path doesn't exist)
+set +e
+bash "$REF_DIR/run-tests.sh" "/path/does/not/exist/$$" 2>/dev/null
+rc=$?
+set -e
+assert_exit "nonexistent target -> exit 3" 3 "$rc"
+
+# 2. Unsupported stack -> exit 2 (empty workspace, no manifests)
+WS="$CMP_TMPDIR/run-tests-none"; mkdir -p "$WS"
+set +e
+( cd "$WS" && bash "$REF_DIR/run-tests.sh" 2>/dev/null )
+rc=$?
+set -e
+assert_exit "no manifests -> exit 2" 2 "$rc"
+
+# 3. Python stack routes to pytest. Verify by stubbing `python` on PATH so the
+#    helper invokes our recorder instead of the real interpreter. The recorder
+#    captures argv and exits 0 — enough to confirm the routing without needing
+#    pytest installed in the test env.
+WS="$CMP_TMPDIR/run-tests-py"; mkdir -p "$WS"
+touch "$WS/pyproject.toml"
+BIN="$CMP_TMPDIR/run-tests-py-bin"; mkdir -p "$BIN"
+cat > "$BIN/python" <<EOF
+#!/usr/bin/env bash
+echo "ARGS: \$*" > "$WS/captured.txt"
+exit 0
+EOF
+chmod +x "$BIN/python"
+set +e
+( cd "$WS" && PATH="$BIN:$PATH" bash "$REF_DIR/run-tests.sh" "" "my_filter" >/dev/null 2>&1 )
+rc=$?
+set -e
+assert_exit "python stack routes (exit 0 from stub)" 0 "$rc"
+if [ -f "$WS/captured.txt" ] && grep -q -- "-m pytest" "$WS/captured.txt" && grep -q -- "-k my_filter" "$WS/captured.txt"; then
+  echo -e "  ${GREEN}[PASS]${NC} python stack invoked pytest with -k filter"
+  pass=$((pass + 1))
+else
+  echo -e "  ${RED}[FAIL]${NC} pytest invocation not captured as expected"
+  [ -f "$WS/captured.txt" ] && cat "$WS/captured.txt" | awk '{print "      " $0}'
   fail=$((fail + 1))
 fi
 

--- a/scripts/test-references.sh
+++ b/scripts/test-references.sh
@@ -362,7 +362,7 @@ if [ -f "$WS/captured.txt" ] && grep -q -- "-m pytest" "$WS/captured.txt" && gre
   pass=$((pass + 1))
 else
   echo -e "  ${RED}[FAIL]${NC} pytest invocation not captured as expected"
-  [ -f "$WS/captured.txt" ] && cat "$WS/captured.txt" | awk '{print "      " $0}'
+  [ -f "$WS/captured.txt" ] && awk '{print "      " $0}' "$WS/captured.txt"
   fail=$((fail + 1))
 fi
 

--- a/skills/assemble-team.md
+++ b/skills/assemble-team.md
@@ -1,6 +1,7 @@
 ---
 name: assemble-team
 description: Analyze a project and assemble an optimal agent team — enforces brainstorming/spec gate before implementation for new-project mode.
+disable-model-invocation: true
 arguments:
   - name: mode
     description: "new-project or existing-project"

--- a/skills/fix-issue.md
+++ b/skills/fix-issue.md
@@ -73,9 +73,11 @@ location the script would have printed.
 Before touching any implementation:
 1. Find the relevant test file (or create one if none exists)
 2. Write a test that fails with the current broken behavior
-3. Run the tests and confirm the new test is RED:
+3. Run the tests and confirm the new test is RED. Use the shared runner — it
+   stack-detects via `detect-stack.sh` and picks the right command, so this
+   works on Python and Node projects without hardcoding either:
 ```bash
-python -m pytest tests/ -v --tb=short -k "test_<relevant_name>"
+bash skills/references/run-tests.sh "$TEST_FILE" "test_<relevant_name>"
 ```
 
 ### Step 5: Fix the bug
@@ -84,7 +86,7 @@ Do not refactor unrelated code. Do not change existing tests.
 
 ### Step 6: Verify all tests are green
 ```bash
-python -m pytest tests/ -v --tb=short
+bash skills/references/run-tests.sh
 ```
 If any tests fail (including pre-existing ones), fix them before proceeding.
 

--- a/skills/refactor-module.md
+++ b/skills/refactor-module.md
@@ -48,9 +48,14 @@ tests is risky. If multiple candidates exist, prefer the first line (priority or
 script reflects project conventions).
 
 ### Step 3: Capture test baseline
+
+Use the shared runner so the same command works for Python and Node projects
+(internally it stack-detects via `detect-stack.sh`):
+
 ```bash
-python -m pytest <test-file> -v --tb=short 2>&1 | tee /tmp/baseline-results.txt
+bash skills/references/run-tests.sh "$TEST_FILE" 2>&1 | tee /tmp/baseline-results.txt
 ```
+
 Record:
 - Total tests: X passed, Y failed (note: Y should be 0 before refactoring)
 - Test names
@@ -71,7 +76,7 @@ Make targeted changes using the Edit tool. Prefer:
 
 ### Step 6: Run tests after refactor
 ```bash
-python -m pytest <test-file> -v --tb=short
+bash skills/references/run-tests.sh "$TEST_FILE"
 ```
 
 If any tests fail:

--- a/skills/references/run-tests.sh
+++ b/skills/references/run-tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Run the project's test suite, picking the runner from detect-stack.sh.
+# Shared by /fix-issue (Steps 4 + 6) and /refactor-module (Steps 3 + 6) so
+# the choice of "python -m pytest" vs "npm test" stops being hardcoded in
+# the skill bodies (where it was wrong for non-Python projects).
+#
+# Usage:
+#   bash skills/references/run-tests.sh [target] [filter]
+#
+#   target  Optional. Single file or directory to scope the run.
+#   filter  Optional. Test-name substring filter (translated per runner).
+#
+# Output:
+#   The invoked command is printed to stderr prefixed with "+" so callers
+#   (and reviewers) can see exactly what ran. Test output streams straight
+#   through on stdout/stderr — pipe or tee from the caller if needed.
+#
+# Exit codes:
+#   0   — tests passed
+#   1   — tests failed (or runner returned non-zero)
+#   2   — stack not supported by this helper (run tests manually)
+#   3   — bad input (target path does not exist)
+
+set -euo pipefail
+
+TARGET="${1:-}"
+FILTER="${2:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -n "$TARGET" ] && [ ! -e "$TARGET" ]; then
+  echo "[run-tests] target does not exist: $TARGET" >&2
+  exit 3
+fi
+
+STACK="$(bash "$SCRIPT_DIR/detect-stack.sh" . 2>/dev/null || echo "none")"
+
+# Python wins over node when both are present — the project's own examples are
+# Python, and the prior hardcoded behaviour was always pytest. Order-stable so
+# callers can reason about which runner fires on mixed projects.
+case ",${STACK}," in
+  *,python,*)
+    cmd=(python -m pytest)
+    [ -n "$TARGET" ] && cmd+=("$TARGET")
+    cmd+=(-v --tb=short)
+    [ -n "$FILTER" ] && cmd+=(-k "$FILTER")
+    echo "+ ${cmd[*]}" >&2
+    exec "${cmd[@]}"
+    ;;
+  *,node,*)
+    if [ -n "$TARGET" ] || [ -n "$FILTER" ]; then
+      echo "[run-tests] node detected; target/filter are not wired for npm test — running the full suite." >&2
+    fi
+    echo "+ npm test --if-present" >&2
+    exec npm test --if-present
+    ;;
+  *)
+    echo "[run-tests] stack '$STACK' is not yet supported by this helper." >&2
+    echo "[run-tests] Supported: python, node. Run tests manually for now." >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

The audit in #45 covered the bulk of the visibility/determinism/composability work. This PR closes the three real gaps that survived:

- **Visibility** — `/assemble-team` now has `disable-model-invocation: true`. It spawns parallel `Agent`s in worktrees that edit files; the brainstorming spec-gate only fires in `new-project` mode, leaving `existing-project` invocations exposed to model auto-fire on vague feature requests.
- **Determinism** — `/fix-issue` (Steps 4+6) and `/refactor-module` (Steps 3+6) hardcoded `python -m pytest ...`. On a TypeScript project the skill would still instruct Claude to run pytest. New shared helper `skills/references/run-tests.sh` stack-detects via `detect-stack.sh` and routes to pytest (Python) or `npm test --if-present` (Node). Exit codes: `0` pass, `1` fail, `2` unsupported stack with manual-run hint, `3` bad target.
- **Composability** — The four skill bodies above now compose `run-tests.sh` instead of duplicating runner logic.

## Changes

| File | Change |
|---|---|
| `skills/assemble-team.md` | `+disable-model-invocation: true` in frontmatter. |
| `skills/references/run-tests.sh` | **New.** Stack-aware test runner. Filter arg translates to `-k` for pytest; warns on Node when target/filter given. |
| `skills/fix-issue.md` | Steps 4 + 6 now call `run-tests.sh` (was hardcoded pytest). |
| `skills/refactor-module.md` | Steps 3 + 6 now call `run-tests.sh` (was hardcoded pytest). |
| `scripts/test-references.sh` | +4 assertions for `run-tests.sh` — bad target, unsupported stack, pytest routing (verified via PATH-stubbed `python` so the test env doesn't need pytest installed). |
| `docs/skills-guide.md` | Register `run-tests.sh` in the progressive-disclosure table. |

## Deliberately out of scope

- `/gen-commit-message` does not get `disable-model-invocation` — it proposes text but explicitly does *not* execute the commit (the user copies the `git commit -m` line), so blocking model invocation would be cosmetic.
- TODO/FIXME/HACK scan in `/assemble-team` Step 2 is a trivial grep candidate for a future `scan-pending-items.sh` extraction. Low leverage versus this pass.
- `post-tool-use.sh` hook still has its own stack-branching test logic (50+ lines). Different output semantics (coloured `PASS`/`SKIP`/`FAIL`) and runs on every edit — consolidating it with `run-tests.sh` is a separate refactor.

## Test plan

- [x] `bash scripts/test-references.sh` — all 34 assertions PASS (was 30, +4)
- [x] `bash scripts/validate-skills.sh --strict` — all 12 PASS, including new `disable-model-invocation` flag on `assemble-team`
- [x] Working-tree mutation guard in `test-references.sh` confirms no untracked changes
- [ ] CI: shellcheck/actionlint/jq/secret-scan/structure/cross-platform-smoke gating jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)